### PR TITLE
Specify "class" on composer.json

### DIFF
--- a/en/plugin-intro.md
+++ b/en/plugin-intro.md
@@ -75,7 +75,8 @@ Use this template as a starting point for your `composer.json` file:
     "handle": "plugin-handle",
     "name": "Plugin Name",
     "developer": "Developer Name",
-    "developerUrl": "https://developer-url.com"
+    "developerUrl": "https://developer-url.com",
+    "class": "ns\\prefix\\Plugin"
   }
 }
 ```


### PR DESCRIPTION
When following these docs and trying to install my empty plugin I got:

![image](https://user-images.githubusercontent.com/4906291/32947060-fe99be30-cb91-11e7-842a-4c179f638342.png)

I inspected my third-party working plugins and they had this **class** attribute. I added it and then I could install my empty plugin :)

Is it necessary? Should we add it to the composer template?

Thanks!

**Update:**  I was watching [this hangout@18:29](https://youtu.be/twQY7GbpYGg?t=1109) and realised we only need to have the "class" attribute when our Plugin class file name is other than `Plugin.php` 