### PR TITLE
Update rich-text-fields.md

### DIFF
--- a/en/rich-text-fields.md
+++ b/en/rich-text-fields.md
@@ -2,7 +2,7 @@ Rich Text Fields
 ================
 
 
-Rich Text fields give you a Redactor-powered WYSIWYG editor, which stores HTML.
+Rich Text fields give you a WYSIWYG editor, which stores HTML. To use Rich Text Fields, install the [Redactor](https://github.com/craftcms/redactor) or [CKEditor](https://github.com/craftcms/ckeditor) plugin.
 
 ## Settings
 


### PR DESCRIPTION
Since Craft 3 redactor fields have been removed in favor of new Redactor and CKEditor plugins.
https://github.com/craftcms/docs/blob/v3/en/changes-in-craft-3.md#rich-text-fields