### PR TITLE
Change craft.request.getUrl() has been deprecated

### DIFF
--- a/en/templating/examples/atom-feed.md
+++ b/en/templating/examples/atom-feed.md
@@ -10,9 +10,9 @@ The following template can be used to provide an Atom 1.0 feed on your site. It 
 
     <title>{{ siteName }}</title>
     <link href="{{ siteUrl }}" />
-    <link type="application/atom+xml" rel="self" href="{{ craft.request.url }}" />
+    <link type="application/atom+xml" rel="self" href="{{ craft.app.request.absoluteUrl }}" />
     <updated>{{ now|atom }}</updated>
-    <id>{{ craft.request.url }}</id>
+    <id>{{ craft.app.request.absoluteUrl }}</id>
     <author>
         <name>{{ globals.feedAuthorName }}</name>
         <email>{{ globals.feedAuthorEmail }}</email>

--- a/en/templating/examples/rss-feed.md
+++ b/en/templating/examples/rss-feed.md
@@ -10,7 +10,7 @@ The following template can be used to provide a RSS 2.0 feed on your site. It as
     <channel>
         <title>{{ siteName }}</title>
         <link>{{ siteUrl }}</link>
-        <atom:link href="{{ craft.request.url }}" rel="self" type="application/rss+xml" />
+        <atom:link href="{{ craft.app.request.absoluteUrl }}" rel="self" type="application/rss+xml" />
         <description>{{ globals.siteDescription }}</description>
         <language>en-us</language>
         <pubDate>{{ now|rss }}</pubDate>


### PR DESCRIPTION
craft.request.getUrl() has been deprecated. Use craft.app.request.absoluteUrl instead.