### PR TITLE
 Used a deprecated method in some fields docs

### DIFF
--- a/en/entries-fields.md
+++ b/en/entries-fields.md
@@ -36,7 +36,7 @@ That will give you an [element query](element-queries.md), prepped to output all
 ```twig
 {% set entries = craft.entries({
     relatedTo: { sourceElement: entry, field: "entriesFieldHandle" },
-    order:     "sortOrder",
+    orderBy:     "sortOrder",
     limit:     null
 }) %}
 ```
@@ -53,10 +53,10 @@ To check if your Entries field has any selected entries, you can use the `length
 {% endif %}
 ```
 
-To loop through the selected entries, you can treat the field like an array:
+To loop through the selected entries:
 
 ```twig
-{% for entry in entry.entriesFieldHandle %}
+{% for entry in entry.entriesFieldHandle.all() %}
     ...
 {% endfor %}
 ```
@@ -82,10 +82,10 @@ You can add parameters to the ElementCriteriaModel object as well:
 {% set newsEntries = entry.entriesFieldHandle.section('news') %}
 ```
 
-If your Entries field is only meant to have a single entry selected, remember that calling your Entries field will still give you the same ElementCriteriaModel, not the selected entry. To get the first (and only) entry selected, use `first()`:
+If your Entries field is only meant to have a single entry selected, remember that calling your Entries field will still give you the same ElementCriteriaModel, not the selected entry. To get the first (and only) entry selected, use `one()`:
 
 ```twig
-{% set entry = entry.myEntriesField.first() %}
+{% set entry = entry.myEntriesField.one() %}
 
 {% if entry %}
     ...

--- a/en/users-fields.md
+++ b/en/users-fields.md
@@ -31,7 +31,7 @@ That will give you an [element query](element-queries.md), prepped to output all
 ```twig
 {% craft.users({
     relatedTo: { sourceElement: entry, field: "usersFieldHandle" },
-    order:     "sortOrder",
+    orderBy:     "sortOrder",
     limit:     null
 }) %}
 ```
@@ -48,10 +48,10 @@ To check if your Users field has any selected users, you can use the `length` fi
 {% endif %}
 ```
 
-To loop through the selected users, you can treat the field like an array:
+To loop through the selected users:
 
 ```twig
-{% for user in entry.usersFieldHandle %}
+{% for user in entry.usersFieldHandle.all() %}
     ...
 {% endfor %}
 ```
@@ -77,10 +77,10 @@ You can add parameters to the ElementCriteriaModel object as well:
 {% set authors = entry.usersFieldHandle.group('authors') %}
 ```
 
-If your Users field is only meant to have a single user selected, remember that calling your Users field will still give you the same ElementCriteriaModel, not the selected user. To get the first (and only) user selected, use `first()`:
+If your Users field is only meant to have a single user selected, remember that calling your Users field will still give you the same ElementCriteriaModel, not the selected user. To get the first (and only) user selected, use `one()`:
 
 ```twig
-{% set user = entry.myUsersField.first() %}
+{% set user = entry.myUsersField.one() %}
 
 {% if user %}
     ...


### PR DESCRIPTION
Since there are methods that are deprecated, in docs we should use there new replacement. 