### PR TITLE
Call of deprecated method.

### DIFF
--- a/en/templating/tags/paginate.md
+++ b/en/templating/tags/paginate.md
@@ -30,7 +30,7 @@ The `{% paginate %}` tag has the following parameters:
 
 The first thing you pass into the `{% paginate %}` tag is an [Element Query](../../element-queries.md) object, which defines all of the elements that should be paginated. Use the `limit` parameter to define how many elements should show up per page.
 
-Warning: This parameter needs to be an actual ElementCriteriaModel object; not an array of elements. So don’t call `find()` on the object.
+Warning: This parameter needs to be an actual ElementCriteriaModel object; not an array of elements. So don’t call `all()` on the object.
 
 ### `as`
 


### PR DESCRIPTION
`find()` method is now deprecated in Craft 3, and will be completely removed in Craft 4:

https://github.com/craftcms/docs/blob/v3/en/changes-in-craft-3.md#query-methods