### PR TITLE
Change public_html to web

### DIFF
--- a/docs/changes-in-craft-3.md
+++ b/docs/changes-in-craft-3.md
@@ -143,7 +143,7 @@ User photos are stored as assets now. When upgrading to Craft 3, Craft will auto
 
 Here’s how you can resolve this:
 
-1. Move the `storage/userphotos/` folder somewhere below your web root (e.g. `public_html/userphotos/`)
+1. Move the `storage/userphotos/` folder somewhere below your web root (e.g. `web/userphotos/`)
 2. Go to Settings → Assets → Volumes → User Photos and configure the volume based on the new folder location:
     - Update the File System Path setting to point to the new folder location
     - Enable the “Assets in this volume have public URLs” setting


### PR DESCRIPTION
Change `public_html` to `web`  because `web` is the default web root folder in Craft 3 and to ensure consistency with the rest of the docs.