### PR TITLE
Fixed typo

### DIFF
--- a/docs/templating/tags/js.md
+++ b/docs/templating/tags/js.md
@@ -17,7 +17,7 @@ The tag calls [yii\web\View::registerJs()](http://www.yiiframework.com/doc-2.0/y
 
 ```twig
 {% set script = '_gaq.push(["_trackEvent", "Search", "'~searchTerm|e('js')~'"' %}
-{% do view.registerJs(styles) %}
+{% do view.registerJs(script) %}
 ```
 :::
 


### PR DESCRIPTION
Looks like there was a copy & paste error between `css` and `js`.