### PR TITLE
Document ability to set 'hasCpSection' in plugin composer.json file

### DIFF
--- a/docs/cp-section.md
+++ b/docs/cp-section.md
@@ -17,6 +17,16 @@ class Plugin extends \craft\base\Plugin
 
 With that in place, Craft will add a new user permission for your plugin, and users that have it will get a new item in their global Control Panel nav, pointing to `/admin/plugin-handle`.
 
+Alternatively, you can add a `hasCpSection` property to the `extra` attribute of your plugin's composer.json file. Keep in mind that Craft will always favour the value defined in the composer.json file rather than in your Plugin class.
+
+```
+{
+    "extra": {
+        "hasCpSection": true
+    }
+}
+```
+
 By default, when someone goes to `/admin/plugin-handle`, Craft will look for an `index.html` or `index.twig` template within your plugin’s `templates/` directory (which should go in your plugin’s source directory).
 
 At a minimum, that template should extend Craft’s `_layouts/cp` layout template, set a `title` variable, and override the `content` block.

--- a/docs/cp-section.md
+++ b/docs/cp-section.md
@@ -15,17 +15,20 @@ class Plugin extends \craft\base\Plugin
 }
 ```
 
-With that in place, Craft will add a new user permission for your plugin, and users that have it will get a new item in their global Control Panel nav, pointing to `/admin/plugin-handle`.
+::: tip
+Alternatively, you can set this from your plugin’s `composer.json` file, via `extra.hasCpSection`.
 
-Alternatively, you can add a `hasCpSection` property to the `extra` attribute of your plugin's composer.json file. Keep in mind that Craft will always favour the value defined in the composer.json file rather than in your Plugin class.
-
-```
+```json
 {
-    "extra": {
-        "hasCpSection": true
-    }
+  "extra": {
+    // ...
+    "hasCpSection": true
+  }
 }
 ```
+:::
+
+With that in place, Craft will add a new user permission for your plugin, and users that have it will get a new item in their global Control Panel nav, pointing to `/admin/plugin-handle`.
 
 By default, when someone goes to `/admin/plugin-handle`, Craft will look for an `index.html` or `index.twig` template within your plugin’s `templates/` directory (which should go in your plugin’s source directory).
 


### PR DESCRIPTION
This feature was missing from the docs. This is especially confusing since the scaffolding created by pluginfactory.io uses the composer.json method for indicating that a plugin should have a control panel section.