### PR TITLE
Update search-form.md

### DIFF
--- a/docs/templating/examples/search-form.md
+++ b/docs/templating/examples/search-form.md
@@ -15,7 +15,7 @@ Then, on whatever template your form submits to (e.g. `search/results.html`), ju
 <h1>Search Results</h1>
 
 {% set query = craft.app.request.getParam('q') %}
-{% set entries = craft.entries.search(query).order('score').all() %}
+{% set entries = craft.entries.search(query).orderBy('score').all() %}
 
 {% if entries|length %}
     <p>{{ entries|length }} results:</p>


### PR DESCRIPTION
The “order” element query param has been deprecated. Use “orderBy” instead.