### PR TITLE
fixed syntax error

### DIFF
--- a/docs/templating/tests.md
+++ b/docs/templating/tests.md
@@ -7,7 +7,7 @@ In addition to the template tags that [Twig comes with](http://twig.sensiolabs.o
 Returns whether an object is an instance of another object or class.
 
 ```twig
-{% if element is instance of ('craft\\elements\\Entry') %}
+{% if element is instance of('craft\\elements\\Entry') %}
     <h1>{{ entry.title }}</h1>
 {% endif %}
 ```

--- a/docs/templating/tests.md
+++ b/docs/templating/tests.md
@@ -7,7 +7,7 @@ In addition to the template tags that [Twig comes with](http://twig.sensiolabs.o
 Returns whether an object is an instance of another object or class.
 
 ```twig
-{% if element is instance of 'craft\\elements\\Entry' %}
+{% if element is instance of ('craft\\elements\\Entry') %}
     <h1>{{ entry.title }}</h1>
 {% endif %}
 ```


### PR DESCRIPTION
I received the error Unexpected token "string" of value "craft\\elements\\Entry" ("end of statement block" expected). With the example code, inserting `("craft\\elements\\Entry")` fixed it