### PR TITLE
Fixed Twig syntax

### DIFF
--- a/docs/dev/element-queries/README.md
+++ b/docs/dev/element-queries/README.md
@@ -88,7 +88,7 @@ $entries = $query->all();
 :::
 
 ::: warning
-If you want to set the `orderBy` parameter like this, you must use the `['columnName' => SORT_ASC]` syntax rather than `'columnName asc'`.
+If you want to set the `orderBy` parameter like this, you must use the `{'columnName': SORT_ASC}` syntax rather than `'columnName asc'`.
 :::
 
 ### Param Value Syntax
@@ -126,7 +126,7 @@ For example, if you want to load entries with a custom `eventDate` field set wit
 use craft\elements\Entry;
 
 $start = new \DateTime('first day of next month')->format(\DateTime::ATOM);
-$end =  new \DateTime('last day of next month')->format(\DateTime::ATOM);
+$end = new \DateTime('last day of next month')->format(\DateTime::ATOM);
 $entries = Entry::find()
     ->section('events')
     ->eventDate(['and', ">= {$start}", "<= {$end}"])

--- a/docs/dev/element-queries/README.md
+++ b/docs/dev/element-queries/README.md
@@ -124,9 +124,10 @@ For example, if you want to load entries with a custom `eventDate` field set wit
 ```
 ```php{7}
 use craft\elements\Entry;
+use craft\helpers\Db;
 
-$start = new \DateTime('first day of next month');
-$end = new \DateTime('last day of next month');
+$start =  Db::prepareDateForDb(new \DateTime('first day of next month'));
+$end =  Db::prepareDateForDb(new \DateTime('last day of next month'));
 $entries = Entry::find()
     ->section('events')
     ->eventDate(['and', ">= {$start}", "<= {$end}"])

--- a/docs/dev/element-queries/README.md
+++ b/docs/dev/element-queries/README.md
@@ -69,7 +69,7 @@ You can also batch-set parameters like so:
 {% set entries = craft.entries(
     {
         section: 'news',
-        orderBy: ['postDate' => SORT_DESC],
+        orderBy: {'postDate': SORT_DESC},
         limit: 10
     }
 ).all() %}

--- a/docs/dev/element-queries/README.md
+++ b/docs/dev/element-queries/README.md
@@ -124,10 +124,9 @@ For example, if you want to load entries with a custom `eventDate` field set wit
 ```
 ```php{7}
 use craft\elements\Entry;
-use craft\helpers\Db;
 
-$start =  Db::prepareDateForDb(new \DateTime('first day of next month'));
-$end =  Db::prepareDateForDb(new \DateTime('last day of next month'));
+$start = new \DateTime('first day of next month')->format(\DateTime::ATOM);
+$end =  new \DateTime('last day of next month')->format(\DateTime::ATOM);
 $entries = Entry::find()
     ->section('events')
     ->eventDate(['and', ">= {$start}", "<= {$end}"])


### PR DESCRIPTION
Actually there is no `[ x => y]` Twig syntax. at least when I copy paste your code it throws an Exception `An array element must be followed by a comma. Unexpected token "operator" of value "=" ("punctuation" expected with value ",").`