### PR TITLE
Fix table formatting

### DIFF
--- a/docs/templating/requirepermission.md
+++ b/docs/templating/requirepermission.md
@@ -32,11 +32,11 @@ Edit entries | `editEntries:[SectionID]`
 ↳  Publish entries | `publishEntries:[SectionID]`
 ↳  Delete entries | `deleteEntries:[SectionID]`
 ↳  Edit other authors’ entries | `editPeerEntries:[SectionID]`
-      ↳  Publish other authors’ entries | `publishPeerEntries:[SectionID]`
-      ↳  Delete other authors’ entries | `deletePeerEntries:[SectionID]`
+  ↳  Publish other authors’ entries | `publishPeerEntries:[SectionID]`
+  ↳  Delete other authors’ entries | `deletePeerEntries:[SectionID]`
 ↳  Edit other authors’ drafts | `editPeerEntryDrafts:[SectionID]`
-      ↳  Publish other authors’ drafts | `publishPeerEntryDrafts:[SectionID]`
-      ↳  Delete other authors’ drafts | `deletePeerEntryDrafts:[SectionID]`
+  ↳  Publish other authors’ drafts | `publishPeerEntryDrafts:[SectionID]`
+  ↳  Delete other authors’ drafts | `deletePeerEntryDrafts:[SectionID]`
 Edit _[Global Set Name]_ | `editGlobalSet:[GlobalSetID]`
 Edit _[Category Group Name]_ | `editCategories:[CategoryGroupID]`
 View _[Asset Source Name]_ | `viewAssetSource:[SourceID]`


### PR DESCRIPTION
The leading spaces were overriding the formatting of the table and pushing that content out into a code block. I've replaced the six leading spaces with an em space and a normal space – this looks visually right on GitHub but you might need to preview it in the actual docs.