### PR TITLE
Giving more details about config

### DIFF
--- a/docs/templating/forgot-password-form.md
+++ b/docs/templating/forgot-password-form.md
@@ -23,3 +23,7 @@ You can create a Forgot Password form using the following code:
     <input type="submit" value="Submit">
 </form>
 ```
+
+While other pages in the forgot password process have Config options to set a custom path ([setPasswordPath](https://docs.craftcms.com/v2/config-settings.html#users), [setPasswordSuccessPath](https://docs.craftcms.com/v2/config-settings.html#users)), this form doesn't need one designated as it's only linked to by you in your Craft project.
+
+Where Craft needs to generate the links for the two examples given above, Craft never takes users to this template.

--- a/docs/templating/forgot-password-form.md
+++ b/docs/templating/forgot-password-form.md
@@ -24,6 +24,6 @@ You can create a Forgot Password form using the following code:
 </form>
 ```
 
-While other pages in the forgot password process have Config options to set a custom path ([setPasswordPath](https://docs.craftcms.com/v2/config-settings.html#users), [setPasswordSuccessPath](https://docs.craftcms.com/v2/config-settings.html#users)), this form doesn't need one designated as it's only linked to by you in your Craft project.
-
-Where Craft needs to generate the links for the two examples given above, Craft never takes users to this template.
+::: tip
+Craft doesn’t ever automatically create links to your Forgot Password page – only your own templates will link to it – so you don’t need to set any config settings with the path to this page, unlike other pages in the password-reset flow (e.g. <config:setPasswordPath> and <config:setPasswordSuccessPath>).
+:::


### PR DESCRIPTION
Other documentation such as the password reset file (https://docs.craftcms.com/v2/templating/set-password-form.html) give information about config options for setting the path, whereas this one does not. To save users potentially trying to find out if there is any config for this template, tell them straight away it doesn't exist and this template is only ever linked to where you set it in your templates.

Please re-write in the Craft tone of voice 👍 .