### PR TITLE
Fix typo in PostgreSQL privilege requirements

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -69,7 +69,6 @@ The database user you tell Craft to connect with must have the following privile
 
 * `SELECT`
 * `INSERT`
-* `DELETE`
 * `UPDATE`
 * `CREATE`
 * `DELETE`


### PR DESCRIPTION
`DELETE` appears twice; I simply removed the duplicate.