### PR TITLE
Fix php example to use Craft 3 syntax

### DIFF
--- a/docs/dev/filters.md
+++ b/docs/dev/filters.md
@@ -176,8 +176,8 @@ Prefixes the given string with a keyed-hash message authentication code (HMAC), 
 PHP scripts can validate the value via [Security::validateData()](api:yii\base\Security::validateData()):
 
 ```php
-$foo = craft()->request->getPost('foo');
-$foo = craft()->security->validateData($foo);
+$foo = Craft::$app->request->getPost('foo');
+$foo = Craft::$app->security->validateData($foo);
 
 if ($foo !== false) {
     // data is valid


### PR DESCRIPTION
PHP example for the `hash` filter currently uses Craft 2 syntax instead of new Craft 3 syntax.