### PR TITLE
Fix deprecated argument in svg() example

### DIFF
--- a/docs/3.x/dev/functions.md
+++ b/docs/3.x/dev/functions.md
@@ -488,10 +488,10 @@ By default, if you pass an asset or raw markup into the function, the SVG will b
 {{ svg(image, sanitize=false, namespace=false) }}
 ```
 
-You can also specify a custom class name that should be added to the root `<svg>` node using the `class` argument:
+You can also specify a custom class name that should be added to the root `<svg>` node using the `attr` filter:
 
 ```twig
-{{ svg('@webroot/icons/lemon.svg', class='lemon-icon') }}
+{{ svg('@webroot/icons/lemon.svg')|attr({ class: 'lemon-icon' }) }}
 ```
 
 ## `source`

--- a/docs/3.x/dev/functions.md
+++ b/docs/3.x/dev/functions.md
@@ -488,7 +488,7 @@ By default, if you pass an asset or raw markup into the function, the SVG will b
 {{ svg(image, sanitize=false, namespace=false) }}
 ```
 
-You can also specify a custom class name that should be added to the root `<svg>` node using the `attr` filter:
+You can also specify a custom class name that should be added to the root `<svg>` node using the [attr](../filters.md#attr) filter:
 
 ```twig
 {{ svg('@webroot/icons/lemon.svg')|attr({ class: 'lemon-icon' }) }}


### PR DESCRIPTION
The `class` argument of the svg() Twig function has been deprecated. The |attr filter should be used instead.