### PR TITLE
Add Craft's session behaviour to Redis

### DIFF
--- a/docs/3.x/config/README.md
+++ b/docs/3.x/config/README.md
@@ -300,6 +300,11 @@ return [
             // Override the class to use Redis' session class
             $config['class'] = yii\redis\Session::class;
 
+            // Attach Craft's session behaviour
+            $config['as session'] = [
+                'class' => craft\behaviors\SessionBehavior::class,
+            ];
+
             // Instantiate and return it
             return Craft::createObject($config);
         },


### PR DESCRIPTION
### Description

The docs mention that session handlers must be configured with Craft's SessionBehaviour but that isn't included in the sample code. Just been debugging a project which had the Redis config copied straight from the docs and was encountering issues.