### PR TITLE
Fix incorrect link to nav section of Tags page

### DIFF
--- a/docs/3.x/categories.md
+++ b/docs/3.x/categories.md
@@ -77,7 +77,7 @@ We can display a navigation for all the categories in a category group called â€
 1. Create a category query with `craft.categories()`.
 2. Set the [group](#group) parameter on it.
 3. Fetch the categories with `.all()`.
-4. Loop through the categories using a [nav](tags.md#nav) tag to create the navigation HTML.
+4. Loop through the categories using a [nav](dev/tags.html#nav) tag to create the navigation HTML.
 
 ```twig
 {# Create a category query with the 'group' parameter #}


### PR DESCRIPTION
The link in step 4 of the [example categories query](https://craftcms.com/docs/3.x/categories.html#example) currently incorrectly links to the Tags (Element Type) page instead of the Tags (Twig Templating) page.

This pull request fixes the link.