### PR TITLE
warn about `tag` being an xss vector

### DIFF
--- a/docs/3.x/dev/functions.md
+++ b/docs/3.x/dev/functions.md
@@ -552,6 +552,8 @@ If `text` is included in the attributes argument, its value will be HTML-encoded
 
 If `html` is included in the attributes argument (and `text` isn’t), its value will be set as the inner HTML of the tag (without getting HTML-encoded).
 
+**Warning**: This can be an XSS (Cross-site scripting) attack vector. Make sure the input is trusted otherwise, sanitize the input beforehand e.g. using the [`purify`](https://craftcms.com/docs/3.x/dev/filters.html#purify) twig filter.
+
 ```twig
 {{ tag('div', {
     html: 'Hello<br>world'

--- a/docs/3.x/dev/functions.md
+++ b/docs/3.x/dev/functions.md
@@ -552,7 +552,9 @@ If `text` is included in the attributes argument, its value will be HTML-encoded
 
 If `html` is included in the attributes argument (and `text` isn’t), its value will be set as the inner HTML of the tag (without getting HTML-encoded).
 
-**Warning**: This can be an XSS (Cross-site scripting) attack vector. Make sure the input is trusted otherwise, sanitize the input beforehand e.g. using the [`purify`](https://craftcms.com/docs/3.x/dev/filters.html#purify) twig filter.
+::: warning
+Be sure you trust any input you provide via `html` since it could be an XSS (cross-site scripting) attack vector. It’s safer to use `text` wherever possible.
+:::
 
 ```twig
 {{ tag('div', {


### PR DESCRIPTION
### Description
Add a warning about `tag` + `html` key being an xss vector.
I feel it's a good idea to sprinkle these warnings around the areas where HTML can be output raw.
