### PR TITLE
Add search indexes note to GraphQL Mutation docs

### DIFF
--- a/docs/3.x/graphql.md
+++ b/docs/3.x/graphql.md
@@ -1419,7 +1419,9 @@ To save an entry, use the entry type-specific mutation which will have the name 
 
 <!-- END ENTRY MUTATION ARGS -->
 
-The `id`, `uid` and `authorId` arguments do no exist for single entries. This is because single entries have no authors and are identified already by the exact mutation. In a similar fashion, there are additional arguments available for structured entries. For more information, refer to [mutating structure data](#mutating-structure-data)
+The `id`, `uid` and `authorId` arguments do no exist for single entries. This is because single entries have no authors and are identified already by the exact mutation. In a similar fashion, there are additional arguments available for structured entries. For more information, refer to [mutating structure data](#mutating-structure-data).
+
+Note that if you are using Craft as a headless backend where users are unlikely to visit the control panel regularly, you may want to tweak the default queueing driver, so that search indexes remain up-to-date.
 
 #### Saving a Draft
 

--- a/docs/3.x/graphql.md
+++ b/docs/3.x/graphql.md
@@ -1421,7 +1421,7 @@ To save an entry, use the entry type-specific mutation which will have the name 
 
 The `id`, `uid` and `authorId` arguments do no exist for single entries. This is because single entries have no authors and are identified already by the exact mutation. In a similar fashion, there are additional arguments available for structured entries. For more information, refer to [mutating structure data](#mutating-structure-data).
 
-Note that if you are using Craft as a headless backend where users are unlikely to visit the control panel regularly, you may want to tweak the default queueing driver, so that search indexes remain up-to-date.
+Note that if you are using Craft as a headless backend where users are unlikely to visit the control panel regularly, you may want to [tweak the default queueing driver](https://craftcms.com/docs/3.x/graphql.html#mutations), so that search indexes remain up-to-date.
 
 #### Saving a Draft
 


### PR DESCRIPTION
### Description

Following on from https://github.com/craftcms/cms/issues/7032, I think it'd be good to make users aware of the potential search index discrepancies – if they're using the default queueing setup – whilst using GraphQL Mutations.

### Related issues

https://github.com/craftcms/cms/issues/7032
