### PR TITLE
update docs about defaultImageQuality

### DIFF
--- a/docs/2.x/config-settings.md
+++ b/docs/2.x/config-settings.md
@@ -1365,9 +1365,9 @@ Whether Craft should convert any non-ASCII characters in uploaded file names to 
 
 ### `defaultImageQuality`
 
-**Accepts**: A numeric value between 0 and 100, 0 being the lowest quality and smallest file size, and 100 being the highest quality and largest file size
+**Accepts**: A numeric value between 1 and 100, 1 being the lowest quality and smallest file size, and 100 being the highest quality and largest file size
 
-**Default**: `75`
+**Default**: `82`
 
 **Since**: Craft 1.1
 


### PR DESCRIPTION
### Description
Currently setting this option to 0 does not behave as the docs say (lowest quality). Instead it uses the default value I think.
As to why, I don't know since I reached a dead end with `_image->smartResize` in craft\image\Raster and could not find where that function is defined (I checked https://github.com/pixelandtonic/Imagine)


### References
https://github.com/craftcms/cms/blob/acb63745c49e44ce45e10cc17a988f3db489a843/src/config/GeneralConfig.php#L357
https://github.com/craftcms/cms/blob/8634b21f56d00a77c1e9db41816976bf95f1ed86/src/image/Raster.php#L102
