### PR TITLE
Reorder table rows and add X icon

### DIFF
--- a/docs/.vuepress/theme/global-components/XMark.vue
+++ b/docs/.vuepress/theme/global-components/XMark.vue
@@ -1,0 +1,34 @@
+<template>
+  <svg
+    role="img"
+    :aria-hidden="label ? false : true"
+    :aria-label="label"
+    focusable="false"
+    :width="width"
+    :height="height"
+    viewBox="0 0 352 512"
+    fill="#6b7280"
+  >
+        <path d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path>
+  </svg>
+</template>
+
+<script>
+export default {
+  props: {
+    label: {
+      type: String,
+      required: false,
+      default: 'No',
+    },
+    width: {
+      type: Number,
+      default: 18
+    },
+    height: {
+      type: Number,
+      default: 18
+    }
+  }
+};
+</script>

--- a/docs/.vuepress/theme/styles/typography.pcss
+++ b/docs/.vuepress/theme/styles/typography.pcss
@@ -252,4 +252,10 @@
       }
     }
   }
+
+  .croker-table {
+    table tr td:first-child {
+      width: 10%;
+    }
+  }
 }

--- a/docs/3.x/dev/controller-actions.md
+++ b/docs/3.x/dev/controller-actions.md
@@ -52,14 +52,29 @@ Param | Description
 
 ### Output
 
-The output of the action depends on whether the entry save was successful, and whether an `Accept: application/json` header was sent with the request.
+The action’s output depends on whether the entry saved successfully and the request included an `Accept: application/json` header.
 
-Success | JSON | Output
-------- | ---- | ------
-<check-mark/> | <x-mark/> | Redirect response per the hashed `redirect` param.
-<x-mark/> | <x-mark/> | None; the request will be routed per the URI. An `entry` variable will be passed to the resulting template. The template can access validation errors via [getErrors()](yii2:yii\base\Model::getErrors()), [getError()](yii2:yii\base\Model::getError()), etc.
-<check-mark/> | <check-mark/> | JSON response with `success`, `id`, `title`, `slug`, `authorUsername`, `dateCreated`, `dateUpdated`, and `postDate` keys.
-<x-mark/> | <check-mark/> | JSON response with an `errors` key set to the result of [getErrors()](yii2:yii\base\Model::getErrors()).
+#### Standard Request
+
+<span class="croker-table">
+
+Success | Output
+------- | ------
+<check-mark/> | Redirect response per the hashed `redirect` param.
+<x-mark/> | None; the request will be routed per the URI. An `entry` variable will be passed to the resulting template. The template can access validation errors via [getErrors()](yii2:yii\base\Model::getErrors()), [getError()](yii2:yii\base\Model::getError()), etc.
+
+</span>
+
+#### With JSON Request Header
+
+<span class="croker-table">
+
+Success | Output
+------- | ------
+<check-mark/> | JSON response with `success`, `id`, `title`, `slug`, `authorUsername`, `dateCreated`, `dateUpdated`, and `postDate` keys.
+<x-mark/> | JSON response with an `errors` key set to the result of [getErrors()](yii2:yii\base\Model::getErrors()).
+
+</span>
 
 ## <badge vertical="baseline" type="verb">POST</badge> `users/login`
 
@@ -82,14 +97,29 @@ Param | Description
 
 ### Output
 
-The output of the action depends on whether the login was successful, and whether an `Accept: application/json` header was sent with the request.
+The output of the action depends on whether the login was successful and the request included an `Accept: application/json` header.
 
-Success | JSON | Output
-------- | ---- | ------
-<check-mark/> | <x-mark/> | Redirect response per the hashed `redirect` param, or the user session’s return URL.
-<x-mark/> | <x-mark/> | None; the request will be routed per the URI. `loginName`, `rememberMe`, `errorCode`, and `errorMessage` variables will be passed to the resulting template.
-<check-mark/> | <check-mark/> | JSON response with `success` and `returnUrl` keys.
-<x-mark/> | <check-mark/> | JSON response with `errorCode` and `error` keys.
+#### Standard Request
+
+<span class="croker-table">
+
+Success | Output
+------- | ------
+<check-mark/> | Redirect response per the hashed `redirect` param, or the user session’s return URL.
+<x-mark/> | None; the request will be routed per the URI. `loginName`, `rememberMe`, `errorCode`, and `errorMessage` variables will be passed to the resulting template.
+
+</span>
+
+#### With JSON Request Header
+
+<span class="croker-table">
+
+Success | Output
+------- | ------
+<check-mark/> | JSON response with `success` and `returnUrl` keys.
+<x-mark/> | JSON response with `errorCode` and `error` keys.
+
+</span>
 
 ## <badge vertical="baseline" type="verb">POST</badge> `users/save-user`
 
@@ -126,14 +156,29 @@ Param | Description
 
 ### Output
 
-The output of the action depends on whether the user save was successful, and whether an `Accept: application/json` header was sent with the request.
+The output depends on whether the user save action was successful and the request included an `Accept: application/json` header.
 
-Success | JSON | Output
-------- | ---- | ------
-<check-mark/> | <x-mark/> | Redirect response per the hashed `redirect` param, or the <config3:activateAccountSuccessPath> config setting if email verification is not required.
-<x-mark/> | <x-mark/> | None; the request will be routed per the URI. A `user` variable will be passed to the resulting template. The template can access validation errors via [getErrors()](yii2:yii\base\Model::getErrors()), [getError()](yii2:yii\base\Model::getError()), etc.
-<check-mark/> | <check-mark/> | JSON response with `success` and `id` keys.
-<x-mark/> | <check-mark/> | JSON response with an `errors` key.
+#### Standard Request
+
+<span class="croker-table">
+
+Success | Output
+------- | ------
+<check-mark/> | Redirect response per the hashed `redirect` param, or the <config3:activateAccountSuccessPath> config setting if email verification is not required.
+<x-mark/> | None; the request will be routed per the URI. A `user` variable will be passed to the resulting template. The template can access validation errors via [getErrors()](yii2:yii\base\Model::getErrors()), [getError()](yii2:yii\base\Model::getError()), etc.
+
+</span>
+
+#### With JSON Request Header
+
+<span class="croker-table">
+
+Success | Output
+------- | ------
+<check-mark/> | JSON response with `success` and `id` keys.
+<x-mark/> | JSON response with an `errors` key.
+
+</span>
 
 ## <badge vertical="baseline" type="verb">POST</badge> `users/send-password-reset-email`
 
@@ -155,14 +200,29 @@ Param | Description
 
 ### Output
 
-The output of the action depends on whether the reset password email was sent successfully, and whether an `Accept: application/json` header was sent with the request.
+The output of the action depends on whether the reset password email was sent successfully, and whether the request included an `Accept: application/json` header.
 
-Success | JSON | Output
-------- | ---- | ------
-<check-mark/> | <x-mark/> | Redirect response per the hashed `redirect` param.
-<x-mark/> | <x-mark/> | None; the request will be routed per the URI. `errors` and `loginName` variables will be passed to the resulting template.
-<check-mark/> | <check-mark/> | JSON response with a `success` key.
-<x-mark/> | <check-mark/> | JSON response with an `error` key.
+#### Standard Request
+
+<span class="croker-table">
+
+Success | Output
+------- | ------
+<check-mark/> | Redirect response per the hashed `redirect` param.
+<x-mark/> | None; the request will be routed per the URI. `errors` and `loginName` variables will be passed to the resulting template.
+
+</span>
+
+#### With JSON Request Header
+
+<span class="croker-table">
+
+Success | Output
+------- | ------
+<check-mark/> | JSON response with a `success` key.
+<x-mark/> | JSON response with an `error` key.
+
+</span>
 
 ## <badge vertical="baseline" type="verb">POST</badge> `users/set-password`
 
@@ -183,11 +243,26 @@ Param | Description
 
 ### Output
 
-The output of the action depends on whether the password was updated successfully, and whether an `Accept: application/json` header was sent with the request.
+The output of the action depends on whether the password was updated successfully and the request included an `Accept: application/json` header.
 
-Success | JSON | Output
-------- | ---- | ------
-<check-mark/> | <x-mark/> | Redirect response depending on the <config3:autoLoginAfterAccountActivation> and <config3:setPasswordSuccessPath> config settings, and whether the user has access to the control panel.
-<x-mark/> | <x-mark/> | None; the request will be routed per the URI. `errors` , `code`, `id`, and `newUser` variables will be passed to the resulting template.
-<check-mark/> | <check-mark/> | JSON response with `success` and (possibly) `csrfTokenValue` keys.
-<x-mark/> | <check-mark/> | JSON response with an `error` key.
+#### Standard Request
+
+<span class="croker-table">
+
+Success | Output
+------- | ------
+<check-mark/> | Redirect response depending on the <config3:autoLoginAfterAccountActivation> and <config3:setPasswordSuccessPath> config settings, and whether the user has access to the control panel.
+<x-mark/> | None; the request will be routed per the URI. `errors` , `code`, `id`, and `newUser` variables will be passed to the resulting template.
+
+</span>
+
+#### With JSON Request Header
+
+<span class="croker-table">
+
+Success | Output
+------- | ------
+<check-mark/> | JSON response with `success` and (possibly) `csrfTokenValue` keys.
+<x-mark/> | JSON response with an `error` key.
+
+</span>

--- a/docs/3.x/dev/controller-actions.md
+++ b/docs/3.x/dev/controller-actions.md
@@ -56,10 +56,10 @@ The output of the action depends on whether the entry save was successful, and w
 
 Success | JSON | Output
 ------- | ---- | ------
+<check-mark/> | <x-mark/> | Redirect response per the hashed `redirect` param.
+<x-mark/> | <x-mark/> | None; the request will be routed per the URI. An `entry` variable will be passed to the resulting template. The template can access validation errors via [getErrors()](yii2:yii\base\Model::getErrors()), [getError()](yii2:yii\base\Model::getError()), etc.
 <check-mark/> | <check-mark/> | JSON response with `success`, `id`, `title`, `slug`, `authorUsername`, `dateCreated`, `dateUpdated`, and `postDate` keys.
-<check-mark/> | No | Redirect response per the hashed `redirect` param.
-No | <check-mark/> | JSON response with an `errors` key set to the result of [getErrors()](yii2:yii\base\Model::getErrors()).
-No | No | None; the request will be routed per the URI. An `entry` variable will be passed to the resulting template. The template can access validation errors via [getErrors()](yii2:yii\base\Model::getErrors()), [getError()](yii2:yii\base\Model::getError()), etc.
+<x-mark/> | <check-mark/> | JSON response with an `errors` key set to the result of [getErrors()](yii2:yii\base\Model::getErrors()).
 
 ## <badge vertical="baseline" type="verb">POST</badge> `users/login`
 
@@ -86,10 +86,10 @@ The output of the action depends on whether the login was successful, and whethe
 
 Success | JSON | Output
 ------- | ---- | ------
+<check-mark/> | <x-mark/> | Redirect response per the hashed `redirect` param, or the user session’s return URL.
+<x-mark/> | <x-mark/> | None; the request will be routed per the URI. `loginName`, `rememberMe`, `errorCode`, and `errorMessage` variables will be passed to the resulting template.
 <check-mark/> | <check-mark/> | JSON response with `success` and `returnUrl` keys.
-<check-mark/> | No | Redirect response per the hashed `redirect` param, or the user session’s return URL.
-No | <check-mark/> | JSON response with `errorCode` and `error` keys.
-No | No | None; the request will be routed per the URI. `loginName`, `rememberMe`, `errorCode`, and `errorMessage` variables will be passed to the resulting template.
+<x-mark/> | <check-mark/> | JSON response with `errorCode` and `error` keys.
 
 ## <badge vertical="baseline" type="verb">POST</badge> `users/save-user`
 
@@ -130,10 +130,10 @@ The output of the action depends on whether the user save was successful, and wh
 
 Success | JSON | Output
 ------- | ---- | ------
+<check-mark/> | <x-mark/> | Redirect response per the hashed `redirect` param, or the <config3:activateAccountSuccessPath> config setting if email verification is not required.
+<x-mark/> | <x-mark/> | None; the request will be routed per the URI. A `user` variable will be passed to the resulting template. The template can access validation errors via [getErrors()](yii2:yii\base\Model::getErrors()), [getError()](yii2:yii\base\Model::getError()), etc.
 <check-mark/> | <check-mark/> | JSON response with `success` and `id` keys.
-<check-mark/> | No | Redirect response per the hashed `redirect` param, or the <config3:activateAccountSuccessPath> config setting if email verification is not required.
-No | <check-mark/> | JSON response with an `errors` key.
-No | No | None; the request will be routed per the URI. A `user` variable will be passed to the resulting template. The template can access validation errors via [getErrors()](yii2:yii\base\Model::getErrors()), [getError()](yii2:yii\base\Model::getError()), etc.
+<x-mark/> | <check-mark/> | JSON response with an `errors` key.
 
 ## <badge vertical="baseline" type="verb">POST</badge> `users/send-password-reset-email`
 
@@ -159,10 +159,10 @@ The output of the action depends on whether the reset password email was sent su
 
 Success | JSON | Output
 ------- | ---- | ------
+<check-mark/> | <x-mark/> | Redirect response per the hashed `redirect` param.
+<x-mark/> | <x-mark/> | None; the request will be routed per the URI. `errors` and `loginName` variables will be passed to the resulting template.
 <check-mark/> | <check-mark/> | JSON response with a `success` key.
-<check-mark/> | No | Redirect response per the hashed `redirect` param.
-No | <check-mark/> | JSON response with an `error` key.
-No | No | None; the request will be routed per the URI. `errors` and `loginName` variables will be passed to the resulting template.
+<x-mark/> | <check-mark/> | JSON response with an `error` key.
 
 ## <badge vertical="baseline" type="verb">POST</badge> `users/set-password`
 
@@ -187,7 +187,7 @@ The output of the action depends on whether the password was updated successfull
 
 Success | JSON | Output
 ------- | ---- | ------
+<check-mark/> | <x-mark/> | Redirect response depending on the <config3:autoLoginAfterAccountActivation> and <config3:setPasswordSuccessPath> config settings, and whether the user has access to the control panel.
+<x-mark/> | <x-mark/> | None; the request will be routed per the URI. `errors` , `code`, `id`, and `newUser` variables will be passed to the resulting template.
 <check-mark/> | <check-mark/> | JSON response with `success` and (possibly) `csrfTokenValue` keys.
-<check-mark/> | No | Redirect response depending on the <config3:autoLoginAfterAccountActivation> and <config3:setPasswordSuccessPath> config settings, and whether the user has access to the control panel.
-No | <check-mark/> | JSON response with an `error` key.
-No | No | None; the request will be routed per the URI. `errors` , `code`, `id`, and `newUser` variables will be passed to the resulting template.
+<x-mark/> | <check-mark/> | JSON response with an `error` key.


### PR DESCRIPTION
I'm loving [this page](https://craftcms.com/docs/3.x/dev/controller-actions.html), in particular the output tables. In this PR I'm proposing the following changes to hopefully make the tables easier to understand.

1. Switch the order of the rows to display both non-JSON requests (the more common type of request) first.
2. Added a slot for an X icon which is clearer than "No", however I don't see where I would actually add the Vue component for the X icon.

The other thought I had was to break this into two individual tables, the first for non-JSON requests and the second for JSON requests. That would mean that the JSON column is no longer required in the table, one less thing for readers to decode (no pun intended ;).