### PR TITLE
Update section.md

### DIFF
--- a/docs/getting-started-tutorial/configure/section.md
+++ b/docs/getting-started-tutorial/configure/section.md
@@ -106,7 +106,7 @@ Next, let’s create the individual fields for our blog posts:
 6. Create a Matrix field named “Post Content”.\
    Choose “New Field” once more, enter “Post Content” for its name, and choose “Matrix” from the “Field Type” dropdown menu. We’ll use the Configuration setting to define two Block Types that can be added and reordered to build the post content.
    1. First add a text block an author can use to enter rich text.\
-      Choose “+ New block type” and enter “Text” for its name. In the Field Settings section, enter the name “Text” again and select “Rich Text” from the “Field Type” dropdown menu. Since every post should have at least some text, make sure “This field is required” is checked.
+      Choose “+ New block type” and enter “Text” for its name. In the Field Settings section, enter the name “Text” again and select “Redactor” from the “Field Type” dropdown menu. Since every post should have at least some text, make sure “This field is required” is checked.
    2. Add one more block for images.\
       Choose “+ New block type” again and enter “Image” for its name. Enter “Image” again for the “Name” under Field Settings. Mark this field required as well and select “Assets” from the “Field Type” dropdown menu. Restrict uploads to the “Blog” volume, enable “Restrict allowed file types?” and make sure “Image” is checked.
    3. Save the field.


### PR DESCRIPTION
The dropdown actually says "Redactor" not "Rich Text".

### Description
The tutorial says choose "Rich Text" for the field type from the dropdown in the blog content matrix field.  The dropdown actually doesn't contain an entry called "Rich Text", but rather "Redactor" as type, making this section confusing.


### Related issues

