### PR TITLE
Update Nitro 2.x Upgrade Docs

### DIFF
--- a/docs/nitro/2.x/upgrade.md
+++ b/docs/nitro/2.x/upgrade.md
@@ -15,7 +15,7 @@ To upgrade, you’ll need to do the following:
 ## Back Up Databases and Uninstall Nitro 1
 
 1. Back up databases from the Nitro virtual machine by running `nitro db backup`.
-2. Run `nitro context` and note your Nitro machine’s IP address.
+2. Run `nitro info` and note your Nitro machine’s IP address.
 3. Once your backups have finished, destroy your Nitro machine with `nitro destroy --skip-backup`.
 4. Edit your hosts file (`/etc/hosts`) and remove any lines pointing Nitro sites or the IP address from step 1 (e.g. `192.168.7.64 nitro.test`).
 5. Optionally uninstall Multipass. (Instructions on the [macOS Installation page](https://multipass.run/docs/installing-on-macos).)


### PR DESCRIPTION
### Description

`nitro context` in 1.x prints the contents of `~/.nitro/nitro.yaml`, but not the machine IP.

`nitro info` is probably more appropriate to use here to get the Nitro 1.x machine's IP address.