### PR TITLE
Plugin code should be symlinked

### DIFF
--- a/docs/nitro/2.x/plugin-development.md
+++ b/docs/nitro/2.x/plugin-development.md
@@ -29,7 +29,6 @@ Edit your `composer.json` to add a `repositories` setting:
 "repositories": [
     {
       "type": "path",
-      "symlink": false,
       "url": "./plugins/commerce"
     }
   ]


### PR DESCRIPTION
### Description

There should be a symlink to the plugin, as the text implies:

> In the output, you will see your plugin referenced using a symlink during the installation.


### Side note

If a symlink would not have been wanted, the configuration should have been:

```json
"repositories": [
    {
      "type": "path",
      "url": "./plugins/commerce",
      "options": {
        "symlink": false
      }
    }
  ]
```
