### PR TITLE
Fix getDiscountByCode query

### DIFF
--- a/docs/commerce/3.x/discounts.md
+++ b/docs/commerce/3.x/discounts.md
@@ -235,7 +235,7 @@ Returns an array of all enabled discounts set up in the system active for the cu
 Returns a [Discount](commerce3:craft\commerce\models\Discount) model that matches the supplied code.
 
 ```twig
-{% set discount = craft.commerce.discount.getDiscountByCode('HALFOFF') %}
+{% set discount = craft.commerce.discounts.getDiscountByCode('HALFOFF') %}
 {% if discount %}
     {{ discount.name }} - {{ discount.description }}
 {% endif %}


### PR DESCRIPTION
### Description
Example twig code for querying a discount by code was incorrect