### PR TITLE
Add response header fields tip to header tag

### DIFF
--- a/docs/3.x/dev/tags.md
+++ b/docs/3.x/dev/tags.md
@@ -284,6 +284,11 @@ The `{% header %}` tag supports the following parameter:
 
 You specify the actual header that should be set by typing it as a string after the word `header`. This parameter is required.
 
+::: tip
+Response header fields need to follow the specification used by the Internet Message Format. If your site uses locales, you might need to add `en` as a third parameter.  
+`{% header "Expires: " ~ expiry|date('D, d M Y H:i:s', 'GMT', 'en') ~ " GMT" %}`
+:::
+
 ## `hook`
 
 This tag gives plugins and modules an opportunity to hook into the template, to either return additional HTML or make changes to the available template variables.


### PR DESCRIPTION
### Description

Used the example code from the docs to write an `expires` header and got this result (with German Umlauts):
`expires: Di., 09 MÃ¤r. 2021 07:52:24 GMT`

Was not an easy fix, as the documentation does not mention the third parameter. Neither Craft’s not Twig’s docs.

Craft `header` tag: (https://craftcms.com/docs/3.x/dev/tags.html#header)  
Twig `date` filter: https://twig.symfony.com/doc/3.x/filters/date.html  
Specs: https://tools.ietf.org/html/rfc7231#section-7.1.1.1  

I guess this might help others.