### PR TITLE
Fixed `activeCartDuration` default description wording.

### DIFF
--- a/docs/commerce/3.x/config-settings.md
+++ b/docs/commerce/3.x/config-settings.md
@@ -175,7 +175,7 @@ Since
 
 
 
-How long a cart should go without being updated before it’s considered inactive. (Defaults to one day.)
+How long a cart should go without being updated before it’s considered inactive. (Defaults to one hour.)
 
 See [craft\helpers\ConfigHelper::durationInSeconds()](craft3:craft\helpers\ConfigHelper::durationInSeconds()) for a list of supported value types.
 


### PR DESCRIPTION
### Description
I notice that we have `@defaultAlt 1 hour` [in the doc block](https://github.com/craftcms/commerce/blob/develop/src/models/Settings.php#L55-L55). Is there any way we can use this in the generation of these docs, or am I asking too much?
