### PR TITLE
document M1 Docker requirements

### DIFF
--- a/docs/3.x/assets-fields.md
+++ b/docs/3.x/assets-fields.md
@@ -90,6 +90,7 @@ Possible values include:
 | `':notempty:'` | that have at least one related asset.
 | `100` | that are related to the asset with an ID of 100.
 | `[100, 200]` | that are related to an asset with an ID of 100 or 200.
+| `[':empty:', 100, 200]` | with no related assets, or are related to an asset with an ID of 100 or 200.
 | `['and', 100, 200]` | that are related to the assets with IDs of 100 and 200.
 | an [Asset](craft3:craft\elements\Asset) object | that are related to the asset.
 | an [AssetQuery](craft3:craft\elements\db\AssetQuery) object | that are related to any of the resulting assets.

--- a/docs/3.x/categories-fields.md
+++ b/docs/3.x/categories-fields.md
@@ -65,6 +65,7 @@ Possible values include:
 | `':notempty:'` | that have at least one related category.
 | `100` | that are related to the category with an ID of 100.
 | `[100, 200]` | that are related to a category with an ID of 100 or 200.
+| `[':empty:', 100, 200]` | with no related categories, or are related to a category with an ID of 100 or 200.
 | `['and', 100, 200]` | that are related to the categories with IDs of 100 and 200.
 | an [Category](craft3:craft\elements\Category) object | that are related to the category.
 | an [CategoryQuery](craft3:craft\elements\db\CategoryQuery) object | that are related to any of the resulting categories.

--- a/docs/3.x/date-time-fields.md
+++ b/docs/3.x/date-time-fields.md
@@ -24,7 +24,6 @@ Possible values include:
 | `'< 2018-05-01'` | that have a date selected before 2018-05-01
 | `['and', '>= 2018-04-01', '< 2018-05-01']` | that have a date selected between 2018-04-01 and 2018-05-01.
 | `['or', '< 2018-04-01', '> 2018-05-01']` | that have a date selected before 2018-04-01 or after 2018-05-01.
-| `['or', ':empty:', '< 2018-04-01']` | that have no a date selected, or a date before 2018-04-01.
 
 ::: code
 ```twig

--- a/docs/3.x/date-time-fields.md
+++ b/docs/3.x/date-time-fields.md
@@ -22,8 +22,9 @@ Possible values include:
 | `':notempty:'` | that have a selected date.
 | `'>= 2018-04-01'` | that have a date selected on or after 2018-04-01.
 | `'< 2018-05-01'` | that have a date selected before 2018-05-01
-| `['and', '>= 2018-04-04', '< 2018-05-01']` | that have a date selected between 2018-04-01 and 2018-05-01.
-| `['or', '< 2018-04-04', '> 2018-05-01']` | that have a date selected before 2018-04-01 or after 2018-05-01.
+| `['and', '>= 2018-04-01', '< 2018-05-01']` | that have a date selected between 2018-04-01 and 2018-05-01.
+| `['or', '< 2018-04-01', '> 2018-05-01']` | that have a date selected before 2018-04-01 or after 2018-05-01.
+| `['or', ':empty:', '< 2018-04-01']` | that have no a date selected, or a date before 2018-04-01.
 
 ::: code
 ```twig

--- a/docs/3.x/entries-fields.md
+++ b/docs/3.x/entries-fields.md
@@ -46,6 +46,7 @@ Possible values include:
 | `':notempty:'` | that have at least one related entry.
 | `100` | that are related to the entry with an ID of 100.
 | `[100, 200]` | that are related to an entry with an ID of 100 or 200.
+| `[':empty:', 100, 200]` | with no related entries, or related to an entry with an ID of 100 or 200.
 | `['and', 100, 200]` | that are related to the entries with IDs of 100 and 200.
 | an [Entry](craft3:craft\elements\Entry) object | that are related to the entry.
 | an [EntryQuery](craft3:craft\elements\db\EntryQuery) object | that are related to any of the resulting entries.

--- a/docs/3.x/tags-fields.md
+++ b/docs/3.x/tags-fields.md
@@ -49,6 +49,7 @@ Possible values include:
 | `':notempty:'` | that have at least one related tag.
 | `100` | that are related to the tag with an ID of 100.
 | `[100, 200]` | that are related to a tag with an ID of 100 or 200.
+| `[':empty:', 100, 200]` | with no related tags, or related to a tag with an ID of 100 or 200.
 | `['and', 100, 200]` | that are related to the tags with IDs of 100 and 200.
 | an [Tag](craft3:craft\elements\Tag) object | that are related to the tag.
 | an [TagQuery](craft3:craft\elements\db\TagQuery) object | that are related to any of the resulting tags.

--- a/docs/3.x/time-fields.md
+++ b/docs/3.x/time-fields.md
@@ -49,7 +49,6 @@ Possible values include:
 | `'< 10:00'` | that have a time selected before 10:00 AM.
 | `['and', '>= 10:00', '< 17:00']` | that have a time selected between 10:00 AM and 5:00 PM.
 | `['or', '< 10:00', '> 17:00']` | that have a time selected before 10:00 AM or after 5:00 PM.
-| `['or', ':empty:', '< 10:00']` | without a selected time, or before 10:00 AM.
 
 ::: code
 ```twig

--- a/docs/3.x/time-fields.md
+++ b/docs/3.x/time-fields.md
@@ -49,6 +49,7 @@ Possible values include:
 | `'< 10:00'` | that have a time selected before 10:00 AM.
 | `['and', '>= 10:00', '< 17:00']` | that have a time selected between 10:00 AM and 5:00 PM.
 | `['or', '< 10:00', '> 17:00']` | that have a time selected before 10:00 AM or after 5:00 PM.
+| `['or', ':empty:', '< 10:00']` | without a selected time, or before 10:00 AM.
 
 ::: code
 ```twig

--- a/docs/3.x/users-fields.md
+++ b/docs/3.x/users-fields.md
@@ -40,6 +40,7 @@ Possible values include:
 | `':notempty:'` | that have at least one related user.
 | `100` | that are related to the user with an ID of 100.
 | `[100, 200]` | that are related to a user with an ID of 100 or 200.
+| `[':empty:', 100, 200]` | without related users, or related to a user with an ID of 100 or 200.
 | `['and', 100, 200]` | that are related to the users with IDs of 100 and 200.
 | an [User](craft3:craft\elements\User) object | that are related to the user.
 | an [UserQuery](craft3:craft\elements\db\UserQuery) object | that are related to any of the resulting users.

--- a/docs/nitro/2.x/installation.md
+++ b/docs/nitro/2.x/installation.md
@@ -1,63 +1,63 @@
 # Installation
 
-## Installing Nitro
+## Installing Nitro for macOS
 
-### macOS
+::: warning
+**If you’re on an M1 Mac**, you must use the [Docker Desktop Apple M1 Tech Preview](https://docs.docker.com/docker-for-mac/apple-m1/) regardless of how you choose to install Nitro.
+:::
 
-You’ll need to install prereleases manually by downloading the appropriate Nitro binary and telling your system to use it.
+1. Install Docker Desktop [Docker Desktop](https://www.docker.com/products/docker-desktop) 3.0.0 or higher.
+2. Install Nitro by opening a terminal and running
+    ````sh
+    bash <(curl -sLS http://installer.getnitro.sh)
+    ````
 
-1. Install Docker Desktop
-    - Intel computers: use [Docker Desktop](https://www.docker.com/products/docker-desktop) 3.0.0 or higher.
-    - Apple M1 computers: use [Docker Apple M1 Tech Preview](https://docs.docker.com/docker-for-mac/apple-m1/).
-2. Install Nitro
-    - either [use Brew](#macos-via-brew)
-    - or open a terminal and run `bash <(curl -sLS http://installer.getnitro.sh)`.
+### macOS via Brew
 
-### Linux
+You can alternatively install Nitro using the [Homebrew](https://brew.sh) package manager if you have it installed.
 
-You’ll need to install prereleases manually by downloading the appropriate Nitro binary and telling your system to use it.
+1. Install Docker Desktop:
+    ```sh
+    brew install homebrew/cask/docker
+    ```
+2. Install Nitro:
+    ```sh
+    brew install craftcms/nitro/nitro
+    ```
+3. Run `nitro init` and follow the prompts to initialize the Nitro environment.
+
+### macOS Manual Installation
+
+If you run into issues with either install method, you can manually install Nitro instead by adding the appropriate binary to your system:
+
+1. Install Docker Desktop [Docker Desktop](https://www.docker.com/products/docker-desktop) 3.0.0 or higher.
+2. Visit Nitro’s [GitHub Releases](https://github.com/craftcms/nitro/releases) page and download the archive for your system.
+3. Extract the release archive and make `nitro` executable with `chmod +x ./nitro`.
+4. Move the binary into your path with `sudo mv ./nitro /usr/local/bin`.
+    ::: tip
+    If the `/usr/local/bin/` directory doesn’t exist, create it with\
+    `sudo mkdir -p -m 775 /usr/local/bin && sudo chown $USER: /usr/local/bin`.
+    :::
+5. Allow Nitro to be trusted by opening your terminal and either
+    - Running `nitro`, choosing **Cancel** for the security prompt, and visiting **System Preferences** → **Security and Privacy** → **General** to choose **Allow Anyway** next to the warning about `nitro` being blocked.
+    - Running the following to strip the quarantine flag macOS adds automatically:\
+    `xattr -dr com.apple.quarantine /usr/local/bin/nitro`
+6. Run `nitro init` and follow the prompts to initialize the Nitro environment.
+
+## Installing Nitro for Linux
 
 1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop) 3.0.0 or higher.
 2. Open a terminal and run `bash <(curl -sLS http://installer.getnitro.sh)`.
 
-#### Manual Installation
+### Linux Manual Installation
 
-If you run into issues with the shell script installer, you can manually install Nitro:
-
-1. Visit Nitro’s [GitHub Releases](https://github.com/craftcms/nitro/releases) page and download the archive for your system.
+1. Visit Nitro’s [GitHub Releases](https://github.com/craftcms/nitro/releases) page and use the `nitro_linux_x86_64.tar.gz` inside your WSL2 instance.
 2. Extract the release archive and make the `nitro` executable with `chmod +x ./nitro`.
 3. If `/usr/local/bin` does not exist for you, create it with `sudo mkdir -p -m 775 /usr/local/bin && sudo chown $USER: /usr/local/bin`.
 4. Move the binary into your path with `sudo mv ./nitro /usr/local/bin`.
+5. Run `nitro init` and follow the prompts to initialize the Nitro environment.
 
-Once the `nitro` executable is in place:
-
-4. In your terminal, run `nitro`, choose **Cancel** for the security prompt, and visit **System Preferences** → **Security and Privacy** → **General** to choose **Allow Anyway** next to the warning about `nitro` being blocked.
-    - Alternatively, you can strip the automatic quarantine flag:
-    ```sh
-    xattr -dr com.apple.quarantine /usr/local/bin/nitro
-    ```
-5. Run `nitro init` and follow the prompts to create your machine.
-
-### macOS via Brew
-
-Using the [Homebrew](https://brew.sh) package manager:
-
-1. Install Docker Desktop:
-    ```bash
-    # This download does not support Apple M1 computers
-    # See above for M1 Docker instructions
-    brew install homebrew/cask/docker
-    ```
-2. Install Nitro:
-    ```bash
-    brew install craftcms/nitro/nitro
-    ```
-3. Initialize Nitro
-    ```bash
-    nitro init
-    ```
-
-### Windows
+## Installing Nitro for Windows
 
 Nitro 2 runs on Windows 10 Home or Pro and requires build 19042 or higher with WSL2.
 
@@ -84,18 +84,20 @@ Read [Developing using Nitro and WSL2](windows.md).
     ```
 10. From the WSL terminal, run `bash <(curl -sLS http://installer.getnitro.sh)`.
 
-If you run into issues with the shell script installer, you can manually install Nitro:
 
-#### Manual Installation
+### Windows Manual Installation
+
+If you run into issues with the shell script installer, you can manually install Nitro:
 
 1. Visit Nitro’s [GitHub Releases](https://github.com/craftcms/nitro/releases) page and use the `nitro_linux_x86_64.tar.gz` inside your WSL2 instance.
 2. Extract the release archive and make the `nitro` executable with `chmod +x ./nitro`.
 3. If `/usr/local/bin` does not exist for you, create it with `sudo mkdir -p -m 775 /usr/local/bin && sudo chown $USER: /usr/local/bin`.
 4. Move the binary into your path with `sudo mv ./nitro /usr/local/bin`.
+5. Run `nitro init` and follow the prompts to initialize the Nitro environment.
 
 ## Uninstalling Nitro
 
-To completely remove Nitro, first [destroy](commands.md#destroy) your machine:
+To completely remove Nitro, first [destroy](commands.md#destroy) its Docker networks, containers, and volumes:
 
 ```bash
 nitro destroy

--- a/docs/nitro/2.x/installation.md
+++ b/docs/nitro/2.x/installation.md
@@ -1,14 +1,20 @@
 # Installation
 
 ## Installing Nitro
-
-### macOS and Linux
+### macOS
 
 You’ll need to install prereleases manually by downloading the appropriate Nitro binary and telling your system to use it.
 
-::: tip
-macOS users can optionally install Nitro [using Brew](#macos-via-brew).
-:::
+1. Install Docker Desktop
+    - Intel computers: use [Docker Desktop](https://www.docker.com/products/docker-desktop) 3.0.0 or higher.
+    - Apple M1 computers: use [Docker Apple M1 Tech Preview](https://docs.docker.com/docker-for-mac/apple-m1/).
+2. Install Nitro
+    - either [use Brew](#macos-via-brew)
+    - or open a terminal and run `bash <(curl -sLS http://installer.getnitro.sh)`.
+
+### Linux
+
+You’ll need to install prereleases manually by downloading the appropriate Nitro binary and telling your system to use it.
 
 1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop) 3.0.0 or higher.
 2. Open a terminal and run `bash <(curl -sLS http://installer.getnitro.sh)`.
@@ -37,6 +43,8 @@ Using the [Homebrew](https://brew.sh) package manager:
 
 1. Install Docker Desktop:
     ```bash
+    # This download does not support Apple M1 computers
+    # See above for M1 Docker instructions
     brew install docker --cask
     ```
 2. Install Nitro:

--- a/docs/nitro/2.x/updating.md
+++ b/docs/nitro/2.x/updating.md
@@ -13,6 +13,14 @@ nitro self-update
 nitro update
 ```
 
+::: warning
+**Windows users** need to use `sudo` for the self-update command:
+```sh
+sudo nitro self-update
+nitro update
+```
+:::
+
 ::: tip
 `self-update` finds the latest stable version of Nitro, but takes a `--dev` argument to include pre-releases:
 


### PR DESCRIPTION
### Description

M1 users have to use the Docker Desktop Tech Preview. This PR adds that fact to the documentation, and adds a link to the relevant Docker page.

### Related issues

Resolves #175
