### PR TITLE
nitro docs: polish homebrew commands

### DIFF
--- a/docs/nitro/2.x/installation.md
+++ b/docs/nitro/2.x/installation.md
@@ -41,8 +41,7 @@ Using the [Homebrew](https://brew.sh) package manager:
     ```
 2. Install Nitro:
     ```bash
-    brew tap craftcms/nitro
-    brew install nitro
+    brew install craftcms/nitro/nitro
     nitro init
     ```
 

--- a/docs/nitro/2.x/installation.md
+++ b/docs/nitro/2.x/installation.md
@@ -42,6 +42,9 @@ Using the [Homebrew](https://brew.sh) package manager:
 2. Install Nitro:
     ```bash
     brew install craftcms/nitro/nitro
+    ```
+3. Initialize Nitro
+    ```bash
     nitro init
     ```
 

--- a/docs/nitro/2.x/installation.md
+++ b/docs/nitro/2.x/installation.md
@@ -37,7 +37,7 @@ Using the [Homebrew](https://brew.sh) package manager:
 
 1. Install Docker Desktop:
     ```bash
-    brew install docker --cask
+    brew install homebrew/cask/docker
     ```
 2. Install Nitro:
     ```bash


### PR DESCRIPTION
### Description

- Updates the Docker Desktop installation command to the latest
- Tightens up the nitro install command (now implicitly taps)

In addition I split `nitro init` into its own distinct step, to match the above Manual instructions' step 5.

### Related issues

Resolves #177 