### PR TITLE
Add documentation on how to append files and preserve relations of assets

### DIFF
--- a/docs/3.x/assets-fields.md
+++ b/docs/3.x/assets-fields.md
@@ -273,7 +273,9 @@ Alternatively, you can submit Base64-encoded file data, which the Assets field w
 {{ hiddenInput('fields[myFieldHandle][filename][]', 'myFile.ext') }}
 ```
 
-To preserve existing relations of assets (append uploaded files):
+However you upload new assets, you may want to maintain any that already exist on the field and append new ones to the set instead of replacing it.
+
+You can do this by passing each of the related asset IDs in the field data array, like we are here with hidden form inputs:
 
 ```twig
 {# Get the currently related asset IDs #}

--- a/docs/3.x/assets-fields.md
+++ b/docs/3.x/assets-fields.md
@@ -259,6 +259,20 @@ Assets fields can handle new file uploads as well:
 }) }}
 ```
 
+::: tip
+Don’t forget to set `enctype="multipart/form-data"` on your `<form>` tag so your browser knows to submit the form as a multipart request.
+:::
+
+Alternatively, you can submit Base64-encoded file data, which the Assets field will decode and treat as an uploaded file. To do that, you have to specify both the data and the filename like this:
+
+```twig
+{{ hiddenInput(
+    'fields[myFieldHandle][data][]',
+    'data:image/jpeg;base64,my-base64-data'
+) }}
+{{ hiddenInput('fields[myFieldHandle][filename][]', 'myFile.ext') }}
+```
+
 To preserve existing relations of assets (append uploaded files):
 
 ```twig
@@ -281,19 +295,6 @@ To preserve existing relations of assets (append uploaded files):
 }) }}
 ```
 
-::: tip
-Don’t forget to set `enctype="multipart/form-data"` on your `<form>` tag so your browser knows to submit the form as a multipart request.
-:::
-
-Alternatively, you can submit Base64-encoded file data, which the Assets field will decode and treat as an uploaded file. To do that, you have to specify both the data and the filename like this:
-
-```twig
-{{ hiddenInput(
-    'fields[myFieldHandle][data][]',
-    'data:image/jpeg;base64,my-base64-data'
-) }}
-{{ hiddenInput('fields[myFieldHandle][filename][]', 'myFile.ext') }}
-```
 
 ## See Also
 

--- a/docs/3.x/assets-fields.md
+++ b/docs/3.x/assets-fields.md
@@ -292,7 +292,6 @@ You can do this by passing each of the related asset IDs in the field data array
 }) }}
 ```
 
-
 ## See Also
 
 * [Asset Queries](assets.md#querying-assets)

--- a/docs/3.x/assets-fields.md
+++ b/docs/3.x/assets-fields.md
@@ -277,18 +277,13 @@ However you upload new assets, you may want to maintain any that already exist o
 
 You can do this by passing each of the related asset IDs in the field data array, like we are here with hidden form inputs:
 
-```twig
-{# Get the currently related asset IDs #}
-{% set relatedAssetIds = entry is defined
-  ? entry.myFieldHandle.ids()
-  : [] %}
-
-{# Create hidden inputs with related asset IDs as value #}
-{% for asset in relatedAssetIds %}
+```twig{1-8}
+{# Provide each existing asset ID in the array of field data #}
+{% for relatedAssetId in entry.myFieldHandle.ids() %}
   {{ input(
       'hidden',
       'fields[myFieldHandle][]',
-      asset.id
+      relatedAssetId
   ) }}
 {% endfor %}
 

--- a/docs/3.x/assets-fields.md
+++ b/docs/3.x/assets-fields.md
@@ -259,6 +259,28 @@ Assets fields can handle new file uploads as well:
 }) }}
 ```
 
+To preserve existing relations of assets (append uploaded files):
+
+```twig
+{# Get the currently related asset IDs #}
+{% set relatedAssetIds = entry is defined
+  ? entry.myFieldHandle.ids()
+  : [] %}
+
+{# Create hidden inputs with related asset IDs as value #}
+{% for asset in relatedAssetIds %}
+  {{ input(
+      'hidden',
+      'fields[myFieldHandle][]',
+      asset.id
+  ) }}
+{% endfor %}
+
+{{ input('file', 'fields[myFieldHandle][]', options={
+  multiple: true,
+}) }}
+```
+
 ::: tip
 Don’t forget to set `enctype="multipart/form-data"` on your `<form>` tag so your browser knows to submit the form as a multipart request.
 :::


### PR DESCRIPTION
Add documentation on how to append files and preserve relations of assets.

### Description

We ran into this today, we wanted to have a front-end upload form and preserve existing relations to already uploaded files. This was not documented and Google didn't have much information about this use case. Hopefully this can helt someone trying to do the same thing.


### Related issues

