### PR TITLE
Update users-fields.md

### DIFF
--- a/docs/3.x/users-fields.md
+++ b/docs/3.x/users-fields.md
@@ -163,7 +163,7 @@ For example, you could create a list of checkboxes for each of the possible rela
 {{ hiddenInput('fields[myFieldHandle]', '') }}
 
 {# Get all of the possible user options #}
-{% set possibleUsers = craft.entries()
+{% set possibleUsers = craft.users()
     .group('authors')
     .orderBy('username ASC')
     .all() %}


### PR DESCRIPTION
Fixed reference to craft.entries

### Description

Saving Users Fields example erroneously references craft.entries() instead of craft.users()

### Related issues

