### PR TITLE
Update console-commands.md

### DIFF
--- a/docs/3.x/console-commands.md
+++ b/docs/3.x/console-commands.md
@@ -1279,7 +1279,7 @@ Ensures all element UIDs are unique.
 
 ## `utils/prune-revisions`
 
-#### `utils/utils/prune-revisions/index` <badge>default</badge>
+#### `utils/prune-revisions/index` <badge>default</badge>
 
 Prunes excess element revisions.
 


### PR DESCRIPTION
Fixed typo in prune revisions sample command (duplicate 'utils')
