### PR TITLE
Update _layout.twig base template

### DIFF
--- a/docs/getting-started-tutorial/build/templates.md
+++ b/docs/getting-started-tutorial/build/templates.md
@@ -18,10 +18,9 @@ Copy this into the `templates/_layout.twig` file you created:
 <!DOCTYPE html>
 <html lang="{{ craft.app.language }}">
   <head>
-    <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta charset="utf-8"/>
     <title>{{ siteName }}</title>
-    <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" name="viewport">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <link href="/styles.css" rel="stylesheet">
   </head>
   <body class="ltr">

--- a/docs/getting-started-tutorial/build/templates.md
+++ b/docs/getting-started-tutorial/build/templates.md
@@ -392,10 +392,9 @@ We used a global set to store a blurb to be displayed at the bottom of all the s
 <!DOCTYPE html>
 <html lang="{{ craft.app.language }}">
   <head>
-    <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta charset="utf-8"/>
     <title>{{ siteName }}</title>
-    <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" name="viewport">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <link href="/styles.css" rel="stylesheet">
   </head>
   <body class="ltr">
@@ -548,10 +547,9 @@ Now let’s include that in `templates/_layout.twig`:
 <!DOCTYPE html>
 <html lang="{{ craft.app.language }}">
   <head>
-    <meta content="IE=edge" http-equiv="X-UA-Compatible">
     <meta charset="utf-8"/>
     <title>{{ siteName }}</title>
-    <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" name="viewport">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
     <link href="/styles.css" rel="stylesheet">
   </head>
   <body class="ltr">


### PR DESCRIPTION
1. Starting with IE11, document modes are deprecated and should no longer be used, except on a temporary basis.
https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/dev-guides/bg182625(v=vs.85)#document-mode-changes

2. Using `maximum-scale=1.0, user-scalable=no` in the viewport meta tag is considered a bad practice because it hinders users to zoom the page in some browsers.  Sites that use this setting are also not WCAG 2.1 AA compliant (https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html).

3. Using `viewport-fit=cover` by default without any CSS or without the CSS you provide causes that some of the page’s content is obscured by the device’s sensor housing, and the bottom navigation bar is very hard to use.
https://webkit.org/blog/7929/designing-websites-for-iphone-x/

### Description



### Related issues

