### PR TITLE
preview targets URIs: clarify object, query, alias/env var syntaxes

### DIFF
--- a/docs/3.x/entries.md
+++ b/docs/3.x/entries.md
@@ -96,6 +96,14 @@ With the above Entry URI Format, a top-level entry’s URI might end up as `docs
 You can designate any one entry as a site’s homepage using a special `__home__` URI.
 :::
 
+::: tip
+You can use an attribute from a query in the entry's URI. Use double curly braces (e.g. `{{craft.entries.section('mySingle').one().slug}}/news`).
+:::
+
+::: tip
+You can use aliases in the entry's URI. Use the `alias()` function in double curly braces (e.g. `{{alias(@rootUrl)}}/news`, `{{alias(@mySectionUri)}}`). See [Environmental Configuration](config/#environmental-configuration) to learn more about how those work.
+:::
+
 ### Preview Targets
 
 If you’re using Craft Pro, your section can have one or more **preview targets**, which are URLs of pages that your entries will show up on, making it possible for authors to preview entries as they are writing them in the control panel.

--- a/docs/3.x/entries.md
+++ b/docs/3.x/entries.md
@@ -102,7 +102,7 @@ If you’re using Craft Pro, your section can have one or more **preview targets
 
 Like entry URI formats, these preview target URLs are mini Twig templates that can contain entry properties and other dynamic values.
 
-If entries in your section have their own URLs, then you can create a preview target for the entry’s primary URL using the URL template, `{url}`.
+Use single curly braces to render attributes on the entry. For example if entries in your section have their own URLs, then you can create a preview target for the entry’s primary URL using the URL template, `{url}`.
 
 Create additional preview targets for any other areas the entry might show up, such as `news`, or `archive/{postDate|date('Y')}`. If the entries show up on the homepage, you can create a preview target with a blank URL.
 
@@ -113,7 +113,11 @@ If you want to include the entry’s ID or UID in a preview target URL, use `{so
 :::
 
 ::: tip
-You can also set the URI to a environment variable (e.g. `$NEWS_INDEX`, or a URL that begins with an alias (e.g. `@rootUrl/news` or `@rootUrl/news/{slug}`). See [Environmental Configuration](config/#environmental-configuration) to learn more about how those work.
+You can use environment variables and aliases in the preview target URL. These do not get wrapped in curly braces (e.g. `$NEWS_INDEX`, `@rootUrl/news`, `@rootUrl/news/{slug}`). See [Environmental Configuration](config/#environmental-configuration) to learn more about how those work.
+:::
+
+::: tip
+Preview target URLs can include an attribute on the result of a query. Here double curly braces must be used (e.g. `{{ craft.entries.section('mySingle').one().url }}`).
 :::
 
 When an author is editing an entry from a section with custom preview targets, the “Share” button will be replaced with a menu that lists the “Primary entry page” (if the section has an Entry URI Format), plus the names of each preview target.

--- a/docs/3.x/fr/entries.md
+++ b/docs/3.x/fr/entries.md
@@ -98,7 +98,7 @@ If you’re using Craft Pro, your section can have one or more **preview targets
 
 Like entry URI formats, these preview target URLs are mini Twig templates that can contain entry properties and other dynamic values.
 
-If entries in your section have their own URLs, then you can create a preview target for the entry’s primary URL using the URL template, `{url}`.
+Use single curly braces to render attributes on the entry. For example if entries in your section have their own URLs, then you can create a preview target for the entry’s primary URL using the URL template, `{url}`.
 
 Create additional preview targets for any other areas the entry might show up, such as `news`, or `archive/{postDate|date('Y')}`. If the entries show up on the homepage, you can create a preview target with a blank URL.
 
@@ -109,7 +109,11 @@ If you want to include the entry’s ID or UID in a preview target URL, use `{so
 :::
 
 ::: tip
-You can also set the URI to a environment variable (e.g. `$NEWS_INDEX`, or a URL that begins with an alias (e.g. `@rootUrl/news` or `@rootUrl/news/{slug}`). See [Environmental Configuration](config/#environmental-configuration) to learn more about how those work.
+You can use environment variables and aliases in the preview target URL. These do not get wrapped in curly braces (e.g. `$NEWS_INDEX`, `@rootUrl/news`, `@rootUrl/news/{slug}`). See [Environmental Configuration](config/#environmental-configuration) to learn more about how those work.
+:::
+
+::: tip
+Preview target URLs can include an attribute on the result of a query. Here double curly braces must be used (e.g. `{{ craft.entries.section('mySingle').one().url }}`).
 :::
 
 When an author is editing an entry from a section with custom preview targets, the “Share” button will be replaced with a menu that lists the “Primary entry page” (if the section has an Entry URI Format), plus the names of each preview target.

--- a/docs/3.x/fr/entries.md
+++ b/docs/3.x/fr/entries.md
@@ -92,6 +92,14 @@ The above template could also be expressed with this syntax:
 
 With the above Entry URI Format, a top-level entry’s URI might end up as `docs/templating`, whereas a nested entry’s URI might end up as `docs/templating/tags`.
 
+::: tip
+You can use an attribute from a query in the entry's URI. Use double curly braces (e.g. `{{craft.entries.section('mySingle').one().slug}}/news`).
+:::
+
+::: tip
+You can use aliases in the entry's URI. Use the `alias()` function in double curly braces (e.g. `{{alias(@rootUrl)}}/news`, `{{alias(@mySectionUri)}}`). See [Environmental Configuration](config/#environmental-configuration) to learn more about how those work.
+:::
+
 ### Preview Targets
 
 If you’re using Craft Pro, your section can have one or more **preview targets**, which are URLs of pages that your entries will show up on, making it possible for authors to preview entries as they are writing them in the control panel.


### PR DESCRIPTION
### Description

Clarifies syntax for four types of dynamic content in preview target URIs:
- object (`{…}`)
    was already documented, but the explanation of what single curly braces does was only up in the "Entry URI Formats" section
- aliases and env vars (`($|@)…`)
    was already documented; minor revision to make it clear that what you do with it is entirely flexible
- and queries (`{{…}}`)
    was not documented

Documents syntax for aliases and queries in entry URI formates (`{{alias(@…)}}`, `{{craft.entries…}}`).


Updates the FR file as well, because it's in a language I speak (English). _Does not_ update the JA file. Can image the FR might need to be reverted, looks like not every EN change is getting mirrored there.

### Related issues

https://github.com/craftcms/cms/issues/7831 (see also https://github.com/craftcms/cms/issues/7820)