### PR TITLE
Fixes mockMethods example

### DIFF
--- a/docs/3.x/testing/framework/mocking.md
+++ b/docs/3.x/testing/framework/mocking.md
@@ -37,14 +37,14 @@ you would have to mock this method. For this, you can use `mockMethods`.
 Mocking your `Externals` service would look something like this:
 
 ```php
-$this->tester->mockMethods([
+$this->tester->mockMethods(
     Mailchimp::getInstance(),
     Externals::class,
     [
         'getUsersFromMailchimp' => [['user1'], ['user2']],
     ],
     []
-]);
+);
 ```
 
 What the above would do is ensure that if


### PR DESCRIPTION
### Description

[`mockMethods`](https://docs.craftcms.com/api/v3/craft-test-craft.html#method-mockmethods) seems to require four arguments, rather than an array like in this example.

### Related issues

I’m also wondering if `Externals::class` is correct or not? I ended up needing to use `Stub::construct` directly, and it only worked with `'externals'` (a string that matched the name of the key used in `setComponents`), rather than `Externals::class`.

So with the following:

```php
// Mailchimp.php
// …

$this->setComponents([
    'externals' => Externals::class,
]);
```

Would the correct example be:

```php
// Don’t need to use Externals here?
// …

$this->tester->mockMethods(
    Mailchimp::getInstance(),
    'externals',
    [
        'getUsersFromMailchimp' => [['user1'], ['user2']],
    ],
    []
);
```

I’m not as sure about this part. Where `$this->instance` is an instance of `Mailchimp`, I ended up with the equivalent of:

```php
$componentInstance = $this->instance->get('externals');
$this->instance->set(
    'externals',
    Stub::construct(
        get_class($componentInstance),
        [],
        [
            'getUsersFromMailchimp' => [['user1'], ['user2']],
        ],
    )
);
```

Thanks!