### PR TITLE
Use wildcard in repositories path

### DIFF
--- a/docs/nitro/2.x/plugin-development.md
+++ b/docs/nitro/2.x/plugin-development.md
@@ -29,7 +29,7 @@ Edit your `composer.json` to add a `repositories` setting:
 "repositories": [
     {
       "type": "path",
-      "url": "./plugins/commerce"
+      "url": "./plugins/*"
     }
   ]
 ```


### PR DESCRIPTION
Using a wildcard in the repositories path means that this step only has to be done once, regardless of how many plugins are added. This seems like a practical thing to do for local plugin development.