### PR TITLE
Change the order of init in the Module

### DIFF
--- a/docs/3.x/extend/module-guide.md
+++ b/docs/3.x/extend/module-guide.md
@@ -87,6 +87,8 @@ class Module extends \yii\base\Module
 {
     public function init()
     {
+        parent::init();
+        
         // Define a custom alias named after the namespace
         Craft::setAlias('@bar', __DIR__);
 
@@ -96,8 +98,6 @@ class Module extends \yii\base\Module
         } else {
             $this->controllerNamespace = 'bar\\controllers';
         }
-
-        parent::init();
 
         // Custom initialization code goes here...
     }


### PR DESCRIPTION
### Description

`parent::init()` in the Module `init()` function rewrites `$this->controllerNamespace`.
So we need first do `parent::init()` and then define custom `$this->controllerNamespace`.