### PR TITLE
Removed `siteUrl` config setting recommendation

### DIFF
--- a/docs/3.x/upgrade.md
+++ b/docs/3.x/upgrade.md
@@ -175,7 +175,7 @@ Some PHP constants have been deprecated in Craft 3, and will no longer work in C
 | Old PHP Constant | What to do instead
 | ---------------- | ----------------------------------------
 | `CRAFT_LOCALE`   | Use the [CRAFT_SITE](config/README.md#craft-site) constant<sup>1</sup>
-| `CRAFT_SITE_URL` | Use the <config3:siteUrl> config setting or [environment variables](config/#environmental-configuration)
+| `CRAFT_SITE_URL` | Use [environment variables](config/#environmental-configuration)
 
 *<sup>1</sup> Craft 3 doesn’t require each site/locale to have its own `index.php` file anymore, so alternatively you can remove all unnecessary site/locale web roots and subfolders. See the [Localization guide](sites.md) for more info.*
 


### PR DESCRIPTION
Because the `siteUrl` config setting no longer exists in Craft 3.