### PR TITLE
Update section.md

### DIFF
--- a/docs/getting-started-tutorial/configure/section.md
+++ b/docs/getting-started-tutorial/configure/section.md
@@ -147,6 +147,7 @@ Next, let’s create the individual fields for our blog posts. With Craft, we ex
       - **This field is required**: checked (Every image block should have an image.)
       - **Field Type**: Assets
       - **Restrict uploads to a single folder?**: checked
+      - **Restrict allowed file types?**: checked
          - Select **Image** to ensure content editors can only select files that are images
    
    Save the field.


### PR DESCRIPTION
Included missing instruction for 'Restrict allowed file types' on line 150

### Description
The documentation for [Create The Blog](https://craftcms.com/docs/getting-started-tutorial/configure/section.html#create-individual-fields) was missing an instruction under Create Blog Fields 6.2


### Related issues

