### PR TITLE
Typo fixes

### DIFF
--- a/docs/3.x/fields.md
+++ b/docs/3.x/fields.md
@@ -57,7 +57,7 @@ Fields can have the following translation method:
 
 If you choose “Custom…”, a “Translation Key Format” setting will appear below, where you can define a template that will help Craft which sites to copy the field value over to. When a new field value is saved, Craft will render this template for all sites, and the field value will be copied to all sites where the translation key matches the original site’s.
 
-For example, if a field’s translation key format were `{site.handle[0:2]}`, then new field values would be copied over to any other sites where the first two characters of the site handle matches the first to characters of the original site’s handle.
+For example, if a field’s translation key format were `{site.handle[0:2]}`, then new field values would be copied over to any other sites where the first two characters of the site handle matches the first two characters of the original site’s handle.
 
 If the translation key format returns an empty string (`''`), the field will not indicate that it’s available for translation. A key format of `{section.handle == 'blog' ? site.handle : ''}`, for example, would display its field as translatable per site from _only_ the `blog` section—otherwise it would not be available for translation in any other context.
 

--- a/docs/commerce/3.x/payment-currencies.md
+++ b/docs/commerce/3.x/payment-currencies.md
@@ -56,9 +56,9 @@ The customer’s payment currency may be defined by a valid 3-digit ISO code for
 
 1. Using the `COMMERCE_PAYMENT_CURRENCY` PHP constant in order to lock the cart’s payment currency to the provided code. You would most likely set this constant in your `index.php` file in a location similar to your `CRAFT_LOCALE` constant.
 
-2. Sending the currency code in a `paymentCurrency` POST parameter when using the `commerce/cart/update-cart` form action. This will have no affect if you’ve set the `COMMERCE_PAYMENT_CURRENCY` constant.
+2. Sending the currency code in a `paymentCurrency` POST parameter when using the `commerce/cart/update-cart` form action. This will have no effect if you’ve set the `COMMERCE_PAYMENT_CURRENCY` constant.
 
-3. Sending the currency code in a `paymentCurrency` POST parameter when using the `commerce/payments/pay` form action. This will also have no affect if you’ve set the `COMMERCE_PAYMENT_CURRENCY` constant.
+3. Sending the currency code in a `paymentCurrency` POST parameter when using the `commerce/payments/pay` form action. This will also have no effect if you’ve set the `COMMERCE_PAYMENT_CURRENCY` constant.
 
 ## Conversion and currency formatting
 

--- a/docs/commerce/3.x/sales.md
+++ b/docs/commerce/3.x/sales.md
@@ -96,7 +96,7 @@ There are additional options for how the sale is applied to the product:
 
 This setting will disregard any previous sale that affected the price of the item matched in this sale.
 
-For example, `Sale 1` reduced the price by 10%. Checking this box within `Sale 2` will apply its affect on the original price of the purchasable, ignoring the 10% off.
+For example, `Sale 1` reduced the price by 10%. Checking this box within `Sale 2` will apply its effect on the original price of the purchasable, ignoring the 10% off.
 
 This is automatically true if either of the following pricing effects are used:
 


### PR DESCRIPTION
### Description

Fix some typos:

- `to` -> `two`
- `affect` -> `effect`