### PR TITLE
Fix references to 'breadcrumbs' in 'Adding Tabs'

### DIFF
--- a/docs/3.x/extend/cp-templates.md
+++ b/docs/3.x/extend/cp-templates.md
@@ -82,14 +82,14 @@ For example, the following `crumbs` array defines two breadcrumbs:
 
 ### Adding Tabs
 
-To add breadcrumbs to your page, define a `tabs` variable, set to a hash of the tabs, indexed by tab IDs.
+To add tabs to your page, define a `tabs` variable, set to a hash of the tabs, indexed by tab IDs.
 
 Each tab should be represented as a nested hash with the following keys:
 
 Key | Description
 --- | -----------
-`label` | The breadcrumb label.
-`url` | The URL or anchor that the breadcrumb should link to.
+`label` | The tab label.
+`url` | The URL or anchor that the tab should link to.
 `class` | A class name that should be added to the tab (in addition to `tab`).
 
 For example, the following `tabs` hash defines two tabs, which will toggle the `hidden` class of `<div>` elements whose IDs match the anchors:


### PR DESCRIPTION
### Description

Fixing a couple of references to 'breadcrumbs' in the Adding Tabs section of Extending the Control Panel -> Control Panel Templates.