### PR TITLE
Include required `LOCK TABLES` permission

### DIFF
--- a/docs/2.x/requirements.md
+++ b/docs/2.x/requirements.md
@@ -54,6 +54,7 @@ The MySQL user you tell Craft to connect with must have the following privileges
 - `INDEX`
 - `DROP`
 - `REFERENCES`
+- `LOCK TABLES`
 
 ## CP Browser Requirements
 


### PR DESCRIPTION
### Description

The lock tables permission is required to allow the DB User to produce an export of the database.
