### PR TITLE
fix add to cart hash prepending in wrong spot

### DIFF
--- a/docs/commerce/3.x/orders-carts.md
+++ b/docs/commerce/3.x/orders-carts.md
@@ -121,7 +121,7 @@ If the product has multiple variants, you could provide a dropdown menu to allow
   {{ csrfInput() }}
   {{ actionInput('commerce/cart/update-cart') }}
   {{ redirectInput('shop/cart') }}
-  {{ hiddenInput('successMessage', 'Added ' ~ product.title ~ ' to cart.'|hash) }}
+  {{ hiddenInput('successMessage', ('Added "' ~ product.title ~ '" to cart.')|hash) }}
   {{ hiddenInput('qty', 1) }}
 
   <select name="purchasableId">


### PR DESCRIPTION
### Description

The hash was added before only the last portion of the string. This patch uses parentheses to group the string so that the hash is prepended to the correct place. Also added quotes around the product title on that line for clarity.

### Related issues

