### PR TITLE
Fix file extension when extending CP layout

### DIFF
--- a/docs/3.x/extend/cp-templates.md
+++ b/docs/3.x/extend/cp-templates.md
@@ -15,7 +15,7 @@ To add a new full page to the control panel, create a template that extends the 
 At a minimum, your template should set a `title` variable and define a `content` block:
 
 ```twig
-{% extends "_layouts/cp.twig" %}
+{% extends "_layouts/cp.html" %}
 {% set title = "Page Title"|t('plugin-handle') %}
 
 {% block content %}

--- a/docs/4.x/extend/cp-templates.md
+++ b/docs/4.x/extend/cp-templates.md
@@ -10,12 +10,12 @@ Modules can have templates too, but they will need to manually define a [templat
 
 ## Page Templates
 
-To add a new full page to the control panel, create a template that extends the [_layouts/cp.html](https://github.com/craftcms/cms/blob/develop/src/templates/_layouts/cp.html) template.
+To add a new full page to the control panel, create a template that extends the [_layouts/cp.twig](https://github.com/craftcms/cms/blob/4.0/src/templates/_layouts/cp.twig) template.
 
 At a minimum, your template should set a `title` variable and define a `content` block:
 
 ```twig
-{% extends "_layouts/cp.html" %}
+{% extends "_layouts/cp.twig" %}
 {% set title = "Page Title"|t('plugin-handle') %}
 
 {% block content %}
@@ -25,7 +25,7 @@ At a minimum, your template should set a `title` variable and define a `content`
 
 ### Supported Variables
 
-The following variables are supported by the `_layouts/cp.html` template:
+The following variables are supported by the `_layouts/cp.twig` template:
 
 Variable | Description
 -------- | -----------
@@ -142,7 +142,7 @@ Variable | Description
 
 #### Form Inputs
 
-Craft’s [_includes/forms.html](https://github.com/craftcms/cms/blob/develop/src/templates/_includes/forms.html) template defines several macros that can be used to display your form elements.
+Craft’s [_includes/forms.twig](https://github.com/craftcms/cms/blob/4.0/src/templates/_includes/forms.twig) template defines several macros that can be used to display your form elements.
 
 Most input types have two macros: one for outputting _just_ the input; and another for outputting the input as a “field”, complete with a label, author instructions, etc.
 

--- a/docs/4.x/extend/cp-templates.md
+++ b/docs/4.x/extend/cp-templates.md
@@ -15,7 +15,7 @@ To add a new full page to the control panel, create a template that extends the 
 At a minimum, your template should set a `title` variable and define a `content` block:
 
 ```twig
-{% extends "_layouts/cp.twig" %}
+{% extends "_layouts/cp.html" %}
 {% set title = "Page Title"|t('plugin-handle') %}
 
 {% block content %}


### PR DESCRIPTION
### Description

The file extension needs to be removed or specified correctly as ".html" when extending the CP layout