### PR TITLE
Move web alias recommendation as a tip to be more prominent.

### DIFF
--- a/docs/3.x/config/README.md
+++ b/docs/3.x/config/README.md
@@ -68,7 +68,11 @@ The following aliases are available out of the box:
 | `@web` | The URL to the folder that contains the `index.php` file that was loaded for the request
 | `@webroot` | The path to the folder that contains the `index.php` file that was loaded for the request
 
-You can override these default aliases with the <config3:aliases> config setting if needed. We recommend overriding the `@web` alias if you plan on using it, to avoid a cache poisoning vulnerability.
+You can override these default aliases with the <config3:aliases> config setting if needed. 
+
+::: tip
+We recommend overriding the `@web` alias if you plan on using it, to avoid a cache poisoning vulnerability.
+:::
 
 ```php
 'aliases' => [

--- a/docs/4.x/config/README.md
+++ b/docs/4.x/config/README.md
@@ -68,7 +68,11 @@ The following aliases are available out of the box:
 | `@web` | The URL to the folder that contains the `index.php` file that was loaded for the request
 | `@webroot` | The path to the folder that contains the `index.php` file that was loaded for the request
 
-You can override these default aliases with the <config4:aliases> config setting if needed. We recommend overriding the `@web` alias if you plan on using it, to avoid a cache poisoning vulnerability.
+You can override these default aliases with the <config4:aliases> config setting if needed. 
+
+::: tip
+We recommend overriding the `@web` alias if you plan on using it, to avoid a cache poisoning vulnerability.
+:::
 
 ```php
 'aliases' => [


### PR DESCRIPTION
### Description

Because of the potential cache poisoning attack vector, the guidance for setting the `@web` alias to something could benefit from being a tip, so it's more prominent and visible. The guidance currently might be a bit lost in the main text currently.

