### PR TITLE
Fix example code for custom config in the upgrade guide

### DIFF
--- a/docs/4.x/upgrade.md
+++ b/docs/4.x/upgrade.md
@@ -61,7 +61,7 @@ Some config settings have been removed in Craft 4:
 | `config/general.php` | `useProjectConfigFile`    | Project config always writes YAML now, but you can [manually control when](https://craftcms.com/docs/4.x/project-config.html#manual-yaml-file-generation).
 
 ::: tip
-You can now set your own config settings—as opposed to those Craft supports—from `config/custom.php`. Any of your custom config settings will be accessible via `Craft::$app->config->{mycustomsetting}`.
+You can now set your own config settings—as opposed to those Craft supports—from `config/custom.php`. Any of your custom config settings will be accessible via `Craft::$app->config->custom->{mycustomsetting}`.
 :::
 
 ### Volumes


### PR DESCRIPTION
### Description

Looks like the example code for custom configs is erroneous. `Craft::$app->config->mycustomsetting` gives an error while `Craft::$app->config->custom->mycustomsetting` gives the correct result.

Should there be an example for Twig as well? Either here or in the _Configuration_ section of the docs? Looks like custom config settings aren't documented at all save in the upgrade guide.

```twig
{{ craft.app.config.custom.mycustomsetting }}
```
