### PR TITLE
Updating windows.md hosts file limitations

### DIFF
--- a/docs/nitro/2.x/windows.md
+++ b/docs/nitro/2.x/windows.md
@@ -65,6 +65,10 @@ For your hostnames to work, add the following to `C:\Windows\System32\Drivers\et
 Nitro attempts to update hostnames when you run `nitro apply`—so you may need to run that after adding your first site.
 :::
 
+::: tip
+Windows only allows for up to nine aliases per line in the hosts file. If you have more than nine, you will need to add any aliases after the ninth one onto a new line below starting with `127.0.0.1`.
+:::
+
 ## Note WSL2 Memory Usage
 
 WSL2 has been known to consume a lot of memory, most noticeably on machines with more limited RAM.


### PR DESCRIPTION
The Windows hosts file seems to have a limitation of up to 9 aliases per line, anything after the ninth alias is not recognised. The way to resolve this is to put anything after the ninth alias on a new line below starting with 127.0.01.

### Description

Hi folks,

I've just finished banging my head against my desk trying to figure out why some of my sites weren't working. After removing Nitro, destroying Nitro, updating Nitro etc. I wasn't getting anywhere.

I pinged each site in the list and realised that they'd stop working at a certain point. After some googling, I learned that you can only have 9 aliases per line in a hosts file. Because I was over the 9 it meant my newer sites wouldn't run at all. This is obviously down to me not having the knowledge of this limitation in the hosts file at the end of the day and not Nitro itself. Hopefully this can save someone time in the future.

### Related issues

When provided with the copy+paste instructions they are all on one line. The hosts file has limitations with reading any aliases after the ninth one.