### PR TITLE
Remove pluginfactory.io from documentation

### DIFF
--- a/docs/4.x/extend/plugin-guide.md
+++ b/docs/4.x/extend/plugin-guide.md
@@ -42,10 +42,6 @@ To create a plugin, create a new directory for it somewhere on your computer. A 
 
 The name of your plugin directory doesn’t matter. Just choose something that is easy to identify.
 
-::: tip
-Use [pluginfactory.io](https://pluginfactory.io/) to create your plugin’s scaffolding with just a few clicks.
-:::
-
 ## composer.json
 
 Create a `composer.json` file at the root of your plugin directory, and use this template as a starting point:


### PR DESCRIPTION
### Description

The plugin factory site says the following:

> Note: pluginfactory.io is no longer maintained, and will be decommissioned at the end of 2022. Listen to this segment on devMode.fm for details

Thus it will not be updated for Craft 4.x and so should no longer be advertised ( :( )


### Related issues

