### PR TITLE
Update example code for custom permissions hook

### DIFF
--- a/docs/4.x/extend/user-permissions.md
+++ b/docs/4.x/extend/user-permissions.md
@@ -15,9 +15,12 @@ public function init()
         UserPermissions::class,
         UserPermissions::EVENT_REGISTER_PERMISSIONS,
         function(RegisterUserPermissionsEvent $event) {
-            $event->permissions['Permission Group Name'] = [
-                'permissionName' => [
-                    'label' => 'Permission Label',
+            $event->permissions[] = [
+                'heading' => 'Permission Group Name',
+                'permissions' => [
+                    'permissionName' => [
+                        'label' => 'Permission Label',
+                    ],
                 ],
             ];
         }


### PR DESCRIPTION
### Description

The example code for registering custom permissions still shows the Craft 3 structure, instead of the new structure required by Craft 4. This PR replaces the example code with the new example from the [upgrade guide](https://craftcms.com/docs/4.x/extend/updating-plugins.html#user-permissions).

