### PR TITLE
Instructions on how to reference alias from php

### DIFF
--- a/docs/4.x/config/README.md
+++ b/docs/4.x/config/README.md
@@ -173,6 +173,14 @@ You can parse aliases in your templates by passing them to the [alias()](../dev/
 ```
 :::
 
+::: tip
+You can parse aliases in your modules or configs by passing them to the getAlias function:
+
+```php
+Craft::getAlias('@webroot');
+```
+:::
+
 ## URL Rules
 
 You can define custom [URL rules](https://www.yiiframework.com/doc/guide/2.0/en/runtime-routing#url-rules) in `config/routes.php`. See [Routing](../routing.md) for more details.


### PR DESCRIPTION
I found this SO article describing what I wanted to do, and felt like it belonged in the docs: https://craftcms.stackexchange.com/questions/26120/how-can-i-use-aliases-in-a-module-plugin

If there is another part of the docs where `Craft::getAlias` is covered, it would be great to link it here, but I couldn't find one.

### Description



### Related issues

