### PR TITLE
Fix CRAFT_STREAM_LOG explanation

### DIFF
--- a/docs/4.x/config/README.md
+++ b/docs/4.x/config/README.md
@@ -707,7 +707,7 @@ Make sure you set this to a valid folder path, otherwise it will be ignored.
 
 ### `CRAFT_STREAM_LOG`
 
-When set to `true`, Craft will additionally send log output to `stderr` and `stdout`. PHP fatal errors will be sent to `stderr`.
+When set to `true`, Craft will send log output to `stderr` and `stdout`, instead of to log files. PHP fatal errors will be sent to `stderr`.
 
 ### `CRAFT_TEMPLATES_PATH`
 


### PR DESCRIPTION
According to https://craftcms.com/docs/4.x/upgrade.html#logging and to the code at https://github.com/craftcms/cms/blob/main/src/log/MonologTarget.php#L193-L215, Craft will _not_ send log output to log files when `CRAFT_STREAM_LOG` is set to `true`.