### PR TITLE
Install: explain that Site URL subdomain must match the ddev project name (related to #397)

### DIFF
--- a/docs/getting-started-tutorial/install/README.md
+++ b/docs/getting-started-tutorial/install/README.md
@@ -7,8 +7,12 @@ The first step is to decide where you want your Craft project to live. If you al
 In your terminal, go to your `tutorial` folder, and run the following command to configure a new DDEV project there:
 
 ```sh
-ddev config --project-name=tutorial --project-type=php --php-version=8.0
+ddev config --project-type=php --php-version=8.0
 ```
+
+::: tip
+This will configure ddev to host your site at https://tutorial.ddev.site, where the subdomain name comes from the folder you created. To use a different ddev subdomain pass the `--project-name` argument, for example `--project-name=my-craft-tutorial`.
+:::
 
 Then run the following command to download the [craftcms/craft](https://github.com/craftcms/craft/) starter project contents, and install its Composer dependencies (namely [craftcms/cms](https://github.com/craftcms/cms/)):
 
@@ -27,6 +31,10 @@ At the end of that command, it will ask whether you’d like to begin the setup.
 - **Database table prefix** → _(leave blank)_
 
 Answer `yes` to the prompt on whether to install Craft now, and answer the remaining prompts as you like. The only one that matters is **Site URL**, which you should answer with `https://tutorial.ddev.site`.
+
+::: warning
+The Site URL subdomain should match the ddev project name. If you specified a project name in the `ddev config` command, use that in place of `tutorial` here. For example `https://my-craft-tutorial.ddev.site`.
+:::
 
 Now set your DDEV web server’s document root to the `web/` folder like so:
 


### PR DESCRIPTION
### Description

I'm new to ddev. To try it out I tried out the latest Craft CMS installation tutorial, with one change: I named my directory `craft-tutorial`. I was surprised that the local domain was not determined by the value I provided for the Site URL (`https://tutorial.ddev.site`) when installing Craft CMS. 

Brandon set me straight https://github.com/craftcms/docs/issues/397#issuecomment-1197487074: the domain is determined by the ddev config, and the Craft CMS Site URL needs to match that. 60033f9072d9d76b5bfb85b48edd9db424165381 helped me, but I still had to do some experimenting to understand. This PR is the information I was looking for to be able to translate the tutorial to any arbitrary setup.

Can imagine you might not want to clutter the first page of the tutorial with asides, but figure no harm in proposing.

### Related issues

- #397