### PR TITLE
Load .env file in tests folder

### DIFF
--- a/docs/4.x/testing/testing-craft/setup.md
+++ b/docs/4.x/testing/testing-craft/setup.md
@@ -111,6 +111,13 @@ define('CRAFT_MIGRATIONS_PATH', __DIR__ . '/_craft/migrations');
 define('CRAFT_TRANSLATIONS_PATH', __DIR__ . '/_craft/translations');
 define('CRAFT_VENDOR_PATH', dirname(__DIR__).'/vendor');
 
+// Load dotenv?
+if (class_exists(Dotenv\Dotenv::class)) {
+    // By default, this will allow .env file values to override environment variables
+    // with matching names. Use `createUnsafeImmutable` to disable this.
+    Dotenv\Dotenv::createUnsafeMutable(CRAFT_TESTS_PATH)->load();
+}
+
 TestSetup::configureCraft();
 ```
 


### PR DESCRIPTION
### Description

Today I tried setting up some PHP tests. For that I followed your [tutorial](https://craftcms.com/docs/4.x/testing/testing-craft/setup.html). However, I struggeled loading the contents of my `tests/.env` file. I found out that for doing that I need to load the `.env` file specifically in my `tests/_bootstrap.php`. Unfortunately, this information was missing in the tutorial. I copied these lines from `bootstrap.php` in https://github.com/craftcms/craft/blob/main/bootstrap.php and adjusted the path. This change made the whole thing working.
