### PR TITLE
Add 'ddev launch' command to install docs

### DIFF
--- a/docs/getting-started-tutorial/install/README.md
+++ b/docs/getting-started-tutorial/install/README.md
@@ -42,6 +42,10 @@ ddev start
 
 In your browser, you should be able to head over to <https://tutorial.ddev.site/> and see the Craft CMS welcome template.
 
+```sh
+ddev launch
+```
+
 <BrowserShot url="https://tutorial.ddev.site/" :link="true">
 <img src="../images/welcome-template.png" alt="Screenshot of the Craft CMS welcome template" />
 </BrowserShot>


### PR DESCRIPTION
### Description

Just an optional PR, I really love `ddev launch` for commandline usage (opens the site in the browser of host system. Also works with `ddev launch /a-sub-path/`

(Details: [ddev launch](https://github.com/drud/ddev/blob/master/pkg/ddevapp/global_dotddev_assets/commands/host/launch))

If it's not relevant in the docs, please just close & deny it. 

Great documentation, much respect!