### PR TITLE
Update Commerce `composer require` example

### DIFF
--- a/docs/commerce/4.x/installation.md
+++ b/docs/commerce/4.x/installation.md
@@ -13,7 +13,7 @@ Log into the control panel, navigate to **Plugin Store** and search for “Comme
 Ensure that you have Composer [installed correctly](/4.x/installation.md#downloading-with-composer), then run the following terminal commands from within your Craft 4 project:
 
 ```bash
-composer require craftcms/commerce
+composer require -w craftcms/commerce
 php craft plugin/install commerce
 ```
 


### PR DESCRIPTION
### Description
Based on how the `composer require` is handled by Craft/Plugin Store using the `-w` by default we should update the installation docs to reflect this.

This solves issues with package conflicts that could occur depending on the order of operations during installation. e.g. https://github.com/craftcms/commerce/issues/2979

