### PR TITLE
Change naming from Urlmanager to UrlManager

### DIFF
--- a/docs/4.x/extend/cp-edit-pages.md
+++ b/docs/4.x/extend/cp-edit-pages.md
@@ -8,7 +8,7 @@ Register two URL rules via <craft4:craft\web\UrlManager::EVENT_REGISTER_CP_URL_R
 
 ```php
 use craft\events\RegisterUrlRulesEvent;
-use craft\web\Urlmanager;
+use craft\web\UrlManager;
 use yii\base\Event;
 
 Event::on(


### PR DESCRIPTION
If someone copies the example with the wrong naming, the event does not get registered and phpStorm does not report any error.
