### PR TITLE
See Also

### DIFF
--- a/docs/.vuepress/theme/components/PageNav.vue
+++ b/docs/.vuepress/theme/components/PageNav.vue
@@ -1,7 +1,17 @@
 <template>
   <div>
-    <div v-if="prev || next" class="page-nav content-wrapper">
-      <p class="inner border-t mt-0 pt-4 overflow-auto">
+    <div v-if="prev || next || relatedItems" class="page-nav content-wrapper">
+      <div v-if="relatedItems" class="inner border-t pt-4">
+        <h4>See Also</h4>
+        <ul>
+          <li v-for="(item, index) in relatedItems" :key="index">
+            <a v-if="item.external" :href="item.uri">{{ item.label }} <OutboundLink /></a>
+            <a v-else :href="item.uri">{{ item.label }}</a>
+          </li>
+        </ul>
+      </div>
+
+      <p class="inner border-t pt-4 overflow-auto" :class="{ 'mt-4': relatedItems }">
         <span v-if="prev" class="prev">
           <span class="paging-arrow inline-block">←</span>
           <a
@@ -59,7 +69,7 @@
 </style>
 
 <script>
-import { resolvePage, resolveHeaders } from "../util";
+import { isExternal, resolvePage, resolveHeaders } from "../util";
 import isString from "lodash/isString";
 import isNil from "lodash/isNil";
 import SidebarLinks from "./SidebarLinks";
@@ -74,6 +84,24 @@ export default {
   computed: {
     headingItems() {
       return resolveHeaders(this.$page);
+    },
+
+    relatedItems() {
+      const related = this.$frontmatter.related;
+
+      if (!related) {
+        return [];
+      }
+
+      return related.map((r) => {
+        const rp = resolvePage(this.$site.pages, r.uri);
+
+        return {
+          label: r.label || rp.title,
+          uri: rp.path,
+          external: isExternal(rp.path),
+        };
+      });
     },
 
     prev() {

--- a/docs/.vuepress/theme/components/PageNav.vue
+++ b/docs/.vuepress/theme/components/PageNav.vue
@@ -1,19 +1,9 @@
 <template>
-  <div>
-    <div v-if="prev || next || relatedItems" class="page-nav content-wrapper">
-      <div v-if="relatedItems" class="inner border-t pt-4">
-        <h4>See Also</h4>
-        <ul>
-          <li v-for="(item, index) in relatedItems" :key="index">
-            <a v-if="item.external" :href="item.uri">{{ item.label }} <OutboundLink /></a>
-            <a v-else :href="item.uri">{{ item.label }}</a>
-          </li>
-        </ul>
-      </div>
-
-      <p class="inner border-t pt-4 overflow-auto" :class="{ 'mt-4': relatedItems }">
-        <span v-if="prev" class="prev">
-          <span class="paging-arrow inline-block">←</span>
+  <div v-if="prev || next || relatedItems.length" class="content-wrapper">
+    <nav class="page-nav">
+      <div v-if="prev || next" class="p-4">
+        <span v-if="prev" class="prev float-left">
+          <span class="paging-arrow inline-block" aria-hidden="true">←</span>
           <a
             v-if="prev.type === 'external'"
             class="prev"
@@ -26,9 +16,7 @@
           </a>
 
           <RouterLink v-else class="prev" :to="prev.path">
-            {{
-            prev.title || prev.path
-            }}
+            {{ prev.title || prev.path }}
           </RouterLink>
         </span>
 
@@ -44,19 +32,37 @@
           </a>
 
           <RouterLink v-else :to="next.path">
-            {{
-            next.title || next.path
-            }}
+            {{ next.title || next.path }}
           </RouterLink>
-          <span class="paging-arrow inline-block">→</span>
+          <span class="paging-arrow inline-block" aria-hidden="true">→</span>
         </span>
-      </p>
-    </div>
+
+        <div class="clear-both"></div>
+      </div>
+
+      <div v-if="relatedItems.length" class="see-also p-4 border-t">
+        <h4 class="font-bold mb-4">See Also</h4>
+        <ul class="list-disc pl-5">
+          {{ /* For raw HTML items, just output the content; URIs that appear to be external resources use an explicit label; Internal URIs will include the label of the referenced page: */ }}
+          <li v-for="(item, index) in relatedItems" :key="index">
+            <div v-if="item.html" v-html="item.html">{{ /* This content may have multiple links within it! */ }}</div>
+            <a
+              v-else-if="item.external"
+              :href="item.uri"
+              target="_blank">{{ item.label }} <OutboundLink /></a>
+            <RouterLink v-else :to="item.uri">{{ item.label }}</RouterLink>
+          </li>
+        </ul>
+      </div>
+    </nav>
   </div>
 </template>
 
 <style lang="postcss">
 .page-nav {
+    @apply rounded;
+    border: 1px solid var(--border-color);
+
   .inner {
     min-height: 2rem;
     border-color: var(--border-color);
@@ -66,20 +72,28 @@
     color: #718096;
   }
 }
+
+.see-also {
+  border-top-color: var(--border-color);
+
+  a {
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
 </style>
 
 <script>
-import { isExternal, resolvePage, resolveHeaders } from "../util";
+import { resolvePage, resolveHeaders } from "../util";
+import resolveRelated from "../util/relationships";
 import isString from "lodash/isString";
 import isNil from "lodash/isNil";
-import SidebarLinks from "./SidebarLinks";
 
 export default {
   name: "PageNav",
 
   props: ["sidebarItems"],
-
-  components: { SidebarLinks },
 
   computed: {
     headingItems() {
@@ -87,21 +101,7 @@ export default {
     },
 
     relatedItems() {
-      const related = this.$frontmatter.related;
-
-      if (!related) {
-        return [];
-      }
-
-      return related.map((r) => {
-        const rp = resolvePage(this.$site.pages, r.uri);
-
-        return {
-          label: r.label || rp.title,
-          uri: rp.path,
-          external: isExternal(rp.path),
-        };
-      });
+      return resolveRelated(this.$page, this.$site);
     },
 
     prev() {

--- a/docs/.vuepress/theme/util/relationships.js
+++ b/docs/.vuepress/theme/util/relationships.js
@@ -1,0 +1,22 @@
+import { isExternal, resolvePage } from "../util";
+
+export default function resolveRelated($page, $site) {
+  const related = $page.frontmatter.related;
+
+  // Nothing defined? Normalize to an empty array:
+  if (!related) {
+    return [];
+  }
+
+  // Ok, there are related items—let's fill in some info about each:
+  return related.map((r) => {
+    const rp = resolvePage($site.pages, r.uri);
+
+    return {
+      label: r.label || rp.title,
+      uri: rp.path,
+      external: isExternal(rp.path),
+      html: r.html,
+    };
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "npm-proj-1656985218704-0.797898673814889tcFElH",
+  "name": "docs",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
### Description

Simple PR enabling output of links stored in YAML frontmatter. Links can be internal references (paths), or external URLs.

Path-based links will pull the target page’s title, by default.
