### PR TITLE
Craft Console

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -12,7 +12,6 @@
       "terms": [
         "Plugin Store",
         "Craft ID",
-        "Craft Console",
         ["(\\s)pdf", "PDF"],
         ["(\\s)png", "PNG"],
         ["(\\s)jpg", "JPG"],

--- a/.textlintrc
+++ b/.textlintrc
@@ -12,6 +12,7 @@
       "terms": [
         "Plugin Store",
         "Craft ID",
+        "Craft Console",
         ["(\\s)pdf", "PDF"],
         ["(\\s)png", "PNG"],
         ["(\\s)jpg", "JPG"],

--- a/docs/3.x/extend/plugin-store.md
+++ b/docs/3.x/extend/plugin-store.md
@@ -21,13 +21,13 @@ If you are going with the Craft License, don’t forget to change the `license` 
 
 ## Registering your Plugin
 
-To register your plugin, first make sure it’s published to a public GitHub repository. Then create a Craft ID account at [id.craftcms.com](https://id.craftcms.com), and connect it to your GitHub account.
+To register your plugin, first make sure it’s published to a public GitHub repository. Then create a Craft Console account at [console.craftcms.com](https://console.craftcms.com), and connect it to your GitHub account.
 
 ::: warning
 If your plugins are published to a GitHub organization account, make sure that the organization is checked when authenticating your GitHub account.
 :::
 
-From your Craft ID account, you’ll need to first go to “Account Settings”, make sure “Enable plugin developer features” is checked under your username, and choose “Save”.
+From your Craft Console account, you’ll need to first go to “Account Settings”, make sure “Enable plugin developer features” is checked under your username, and choose “Save”.
 
 Once plugin developer features are enabled, add your plugin by going to Plugins → “Add a plugin”, and choose the “Select” button next to your plugin’s repository. You will then be able to edit its description, screenshots, and other details.
 
@@ -109,4 +109,4 @@ If you need to transfer ownership of your plugin to another developer, follow th
 1. Visit your plugin’s GitHub repository and click on its **Settings** tab.
 2. Scroll down to the bottom and press the **Transfer** button within the **Danger Zone** section, and submit the transfer form.
 3. The new developer will likely want to [change the package name](#changing-the-package-name) at this point. Once they’ve done so, remember to mark the old package name as abandoned.
-4. Have the new developer contact [support@craftcms.com](mailto:support@craftcms.com) to notify Pixel & Tonic of the change, so we can transfer the plugin to their Craft ID account and update its repository URL and package name.
+4. Have the new developer contact [support@craftcms.com](mailto:support@craftcms.com) to notify Pixel & Tonic of the change, so we can transfer the plugin to their Craft Console account and update its repository URL and package name.

--- a/docs/3.x/plugins.md
+++ b/docs/3.x/plugins.md
@@ -44,11 +44,11 @@ If you purchase a plugin license separately from a Craft install or need to upda
 
 ## Managing Plugin Licenses
 
-You can manage all your plugin licenses from your [Craft ID](https://id.craftcms.com/) account, under **Licenses** → **Plugins**
+You can manage all your plugin licenses from your [Craft Console](https://console.craftcms.com/) account, under **Licenses** → **Plugins**
 
-If you don’t have a Craft ID account yet, you can create one by going to [id.craftcms.com/register](https://id.craftcms.com/register).
+If you don’t have a Craft Console account yet, you can create one by going to [console.craftcms.com/register](https://console.craftcms.com/register).
 
-Any plugin licenses purchased with the same email address as your Craft ID account will automatically be added to your account.
+Any plugin licenses purchased with the same email address as your Craft Console account will automatically be added to your account.
 
 If you have a plugin license that isn’t showing up, visit **Licenses** → **Claim License**. You can enter its license key manually, or if you know the email address that was used for purchase, you can enter it in the **Claim licenses by email address** section. After verifying ownership of the email address, any unclaimed licenses associated with that email address will be added to your account.
 
@@ -60,7 +60,7 @@ If you were to create a `MY_PLUGIN_KEY` environment variable, for example, you c
 
 ## Transferring Plugin Licenses
 
-To transfer a plugin license to someone else’s Craft ID account, log into your Craft ID account, choose the license under **Licenses** → **Plugins**, and choose the **Release License** to release it from your account. Another person will then be able to claim the license for themself from the **Licenses** → **Claim License** page of their Craft ID account.
+To transfer a plugin license to someone else’s Craft Console account, log into your Craft Console account, choose the license under **Licenses** → **Plugins**, and choose the **Release License** to release it from your account. Another person will then be able to claim the license for themself from the **Licenses** → **Claim License** page of their Craft Console account.
 
 ## Commercial Plugin Licensing
 

--- a/docs/4.x/extend/plugin-store.md
+++ b/docs/4.x/extend/plugin-store.md
@@ -21,13 +21,13 @@ If you are going with the Craft License, don’t forget to change the `license` 
 
 ## Registering your Plugin
 
-To register your plugin, first make sure it’s published to a public GitHub repository. Then create a Craft ID account at [id.craftcms.com](https://id.craftcms.com), and connect it to your GitHub account.
+To register your plugin, first make sure it’s published to a public GitHub repository. Then create a Craft Console account at [console.craftcms.com](https://console.craftcms.com), and connect it to your GitHub account.
 
 ::: warning
 If your plugins are published to a GitHub organization account, make sure that the organization is checked when authenticating your GitHub account.
 :::
 
-From your Craft ID account, you’ll need to first go to “Account Settings”, make sure “Enable plugin developer features” is checked under your username, and choose “Save”.
+From your Craft Console account, you’ll need to first go to “Account Settings”, make sure “Enable plugin developer features” is checked under your username, and choose “Save”.
 
 Once plugin developer features are enabled, add your plugin by going to Plugins → “Add a plugin”, and choose the “Select” button next to your plugin’s repository. You will then be able to edit its description, screenshots, and other details.
 
@@ -109,4 +109,4 @@ If you need to transfer ownership of your plugin to another developer, follow th
 1. Visit your plugin’s GitHub repository and click on its **Settings** tab.
 2. Scroll down to the bottom and press the **Transfer** button within the **Danger Zone** section, and submit the transfer form. 
 3. The new developer will likely want to [change the package name](#changing-the-package-name) at this point. Once they’ve done so, remember to mark the old package name as abandoned.
-4. Have the new developer contact [support@craftcms.com](mailto:support@craftcms.com) to notify Pixel & Tonic of the change, so we can transfer the plugin to their Craft ID account and update its repository URL and package name.
+4. Have the new developer contact [support@craftcms.com](mailto:support@craftcms.com) to notify Pixel & Tonic of the change, so we can transfer the plugin to their Craft Console account and update its repository URL and package name.

--- a/docs/4.x/plugins.md
+++ b/docs/4.x/plugins.md
@@ -44,11 +44,11 @@ If you purchase a plugin license separately from a Craft install or need to upda
 
 ## Managing Plugin Licenses
 
-You can manage all your plugin licenses from your [Craft ID](https://id.craftcms.com/) account, under **Licenses** → **Plugins**
+You can manage all your plugin licenses from your [Craft Console](https://console.craftcms.com/) account, under **Licenses** → **Plugins**
 
-If you don’t have a Craft ID account yet, you can create one by going to [id.craftcms.com/register](https://id.craftcms.com/register).
+If you don’t have a Craft Console account yet, you can create one by going to [console.craftcms.com/register](https://console.craftcms.com/register).
 
-Any plugin licenses purchased with the same email address as your Craft ID account will automatically be added to your account.
+Any plugin licenses purchased with the same email address as your Craft Console account will automatically be added to your account.
 
 If you have a plugin license that isn’t showing up, visit **Licenses** → **Claim License**. You can enter its license key manually, or if you know the email address that was used for purchase, you can enter it in the **Claim licenses by email address** section. After verifying ownership of the email address, any unclaimed licenses associated with that email address will be added to your account.
 
@@ -60,7 +60,7 @@ If you were to create a `MY_PLUGIN_KEY` environment variable, for example, you c
 
 ## Transferring Plugin Licenses
 
-To transfer a plugin license to someone else’s Craft ID account, log into your Craft ID account, choose the license under **Licenses** → **Plugins**, and choose the **Release License** to release it from your account. Another person will then be able to claim the license for themself from the **Licenses** → **Claim License** page of their Craft ID account.
+To transfer a plugin license to someone else’s Craft Console account, log into your Craft Console account, choose the license under **Licenses** → **Plugins**, and choose the **Release License** to release it from your account. Another person will then be able to claim the license for themself from the **Licenses** → **Claim License** page of their Craft Console account.
 
 ## Commercial Plugin Licensing
 


### PR DESCRIPTION
Replaces any links to the legacy Craft ID application with the new Craft Console URL.