### PR TITLE
Fix variable order in pagination example

### DIFF
--- a/docs/4.x/element-queries.md
+++ b/docs/4.x/element-queries.md
@@ -331,7 +331,7 @@ The `paginate` tag accepts an element query, sets its `offset` param based on th
   .orderBy('postDate DESC') %}
 
 {# Paginate the query into a `posts` variable: #}
-{% paginate newsQuery as posts, pageInfo %}
+{% paginate newsQuery as pageInfo, posts %}
 
 {# Use the `posts` variable just like you would any other result set: #}
 {% for post in posts %}


### PR DESCRIPTION
The result variable should be second and the page info variable first, as per the [source](https://github.com/craftcms/cms/blob/de44db1d876c18997f3f00bc91677c0582d77a4a/src/web/twig/tokenparsers/PaginateTokenParser.php#L42) and [other examples](https://craftcms.com/docs/4.x/dev/tags.html#paginate) in the docs. Thanks :)