### PR TITLE
Update on payment-gateway-types.md - fix a PHP use

### DIFF
--- a/docs/commerce/4.x/extend/payment-gateway-types.md
+++ b/docs/commerce/4.x/extend/payment-gateway-types.md
@@ -168,7 +168,7 @@ Register your custom gateway type using the [`registerGatewayTypes`](events.md#r
 
 ```php
 use craft\events\RegisterComponentTypesEvent;
-use craft\commerce\services\Purchasables;
+use craft\commerce\services\Gateways;
 use yii\base\Event;
 
 Event::on(


### PR DESCRIPTION
The use craft\commerce\services\Purchasables; is incorrect in the code shown, it needs to be the Gateways service.

### Description



### Related issues

