### PR TITLE
Add missing type-hint to controller example code

### DIFF
--- a/docs/4.x/extend/controllers.md
+++ b/docs/4.x/extend/controllers.md
@@ -50,7 +50,7 @@ use craft\web\Controller;
 
 class WidgetsController extends Controller
 {
-    protected $allowAnonymous = true;
+    protected array|bool|int $allowAnonymous = true;
 
     public function actionEcho()
     {


### PR DESCRIPTION
### Description

The example code for controllers is missing the type-hint for the `$allowAnonymous` property required Craft 4. If taken as-is, the code example will throw an error.