### PR TITLE
Commerce: Added details on manage subscription permission change in Commerce 4

### DIFF
--- a/docs/commerce/4.x/store-management.md
+++ b/docs/commerce/4.x/store-management.md
@@ -82,7 +82,7 @@ Whether the user can delete discounts.
 
 ### Manage subscriptions
 
-Whether the user can see subscriptions, refresh subscription payments, and cancel subscriptions.
+Whether the user can see subscriptions, refresh subscription payments, and cancel subscriptions. This permission is required for subscription customers in order to change, cancel, or reactivate their subscription.
 
 ### Manage shipping <badge text="Pro" type="edition" vertical="middle" title="Commerce Pro only" />
 

--- a/docs/commerce/4.x/subscription-templates.md
+++ b/docs/commerce/4.x/subscription-templates.md
@@ -76,6 +76,8 @@ To cancel a subscription you can use the following template. It assumes the `sub
 
 If you wish to set cancellation parameters, it is strongly recommended to make use of [subscription events](extend/events.md#beforecancelsubscription) instead of POST data.
 
+To cancel a subscription the subscriber must have the [Manage Subscriptions](store-management.md#manage-subscriptions) permission. You can assign this permission to the user group.
+
 ## Switching the subscription plan
 
 To switch a subscription plan you can use the following template. It assumes that `subscription` variable is available and set to an instance of `craft\commerce\elements\Subscription`, and posts to the `commerce/subscriptions/switch` form action:
@@ -99,6 +101,9 @@ To switch a subscription plan you can use the following template. It assumes tha
 
 If you wish to set parameters for switching the subscription plan, it is strongly recommended to make use of [subscription events](extend/events.md#beforeswitchsubscriptionplan) instead of POST data.
 
+To switch a subscription the subscriber must have the [Manage Subscriptions](store-management.md#manage-subscriptions) permission. You can assign this permission to the user group.
+
+
 ## Reactivating a canceled subscription
 
 To reactivate a subscription plan you can use the following template. It assumes the `subscription` variable is available and set to an instance of `craft\commerce\elements\Subscription`, and posts to the `commerce/subscriptions/reactivate` form action.
@@ -118,3 +123,5 @@ To reactivate a subscription plan you can use the following template. It assumes
 ::: warning
 Not all canceled subscriptions might be available for reactivation, so make sure to check for that using `subscription.canReactivate()`.
 :::
+
+To reactivate a subscription the subscriber must have the [Manage Subscriptions](store-management.md#manage-subscriptions) permission. You can assign this permission to the user group.

--- a/docs/commerce/4.x/upgrading.md
+++ b/docs/commerce/4.x/upgrading.md
@@ -482,6 +482,7 @@ Some permissions have changed in Commerce 4:
     - `commerce-createDiscounts`
     - `commerce-deleteDiscounts`
 - `commerce-manageCustomers` has been replaced by Craft’s standard user management permissions.
+- `commerce-manageSubscriptions` is now required for all subscription customers in order to cancel, switch, or reactivate a subscription.
 
 ## Payment Gateways
 


### PR DESCRIPTION
### Description
Added details on manage subscription permission change in Commerce 4
- updated the Commerce 4 upgrade guide to call out the permissions change under Commerce Permissions Changes
- updated the description of the permission under Store Management
- updated the template guide to call out the need for this permission for cancel, reactivate, and switch.