### PR TITLE
New block identifier should be in sortOrder

### DIFF
--- a/docs/4.x/matrix-fields.md
+++ b/docs/4.x/matrix-fields.md
@@ -235,7 +235,8 @@ If you have an element form (such as an [entry form](kb:entry-form)) that needs 
 {
   "sortOrder": [
     321,
-    654
+    654,
+    "new:1"
   ],
   "blocks": {
     "321": {


### PR DESCRIPTION
### Description
New block identifier should be in sortOrder array for matrix field's sample json data.
As docs says: 
> sortOrder should be submitted as an array of all the block IDs you wish to persist (**as well as any new block identifiers**), in the order they should be saved