### PR TITLE
Update snapshot events

### DIFF
--- a/docs/commerce/4.x/extend/events.md
+++ b/docs/commerce/4.x/extend/events.md
@@ -32,7 +32,7 @@ Event::on(
 
         // Add every custom field to the snapshot
         if (($fieldLayout = $variant->getFieldLayout()) !== null) {
-            foreach ($fieldLayout->getFields() as $field) {
+            foreach ($fieldLayout->getCustomFields() as $field) {
                 $fields[] = $field->handle;
             }
         }
@@ -93,7 +93,7 @@ Event::on(
 
         // Add every custom field to the snapshot
         if (($fieldLayout = $product->getFieldLayout()) !== null) {
-            foreach ($fieldLayout->getFields() as $field) {
+            foreach ($fieldLayout->getCustomFields() as $field) {
                 $fields[] = $field->handle;
             }
         }


### PR DESCRIPTION
When implementing the EVENT_BEFORE_CAPTURE_VARIANT_SNAPSHOT and EVENT_BEFORE_CAPTURE_PRODUCT_SNAPSHOT I am getting the following:

"Calling unknown method: craft\models\FieldLayout::getFields()"

Updating to $fieldLayout->getCustomFields() fixes the issue.

### Description



### Related issues

