### PR TITLE
Update element-types.md

### DIFF
--- a/docs/4.x/extend/element-types.md
+++ b/docs/4.x/extend/element-types.md
@@ -1035,7 +1035,7 @@ class Products extends BaseRelationField
         return \Craft::t('plugin-handle', 'Products');
     }
 
-    protected static function elementType(): string
+    public static function elementType(): string
     {
         return Product::class;
     }


### PR DESCRIPTION
Fix example to match `BaseRelationField::elementType()` function.

