### PR TITLE
Fix code error in GraphQL auth token test

### DIFF
--- a/docs/3.x/graphql.md
+++ b/docs/3.x/graphql.md
@@ -256,7 +256,7 @@ If you’re unable to query a private schema because of a “missing authorizati
 
 ```twig
 {{ craft.app.getRequest().getHeaders().has('authorization')
-  ? 'auth token present ✓' :
+  ? 'auth token present ✓'
   : 'auth token missing!' }}
 ```
 

--- a/docs/4.x/graphql.md
+++ b/docs/4.x/graphql.md
@@ -256,7 +256,7 @@ If you’re unable to query a private schema because of a “missing authorizati
 
 ```twig
 {{ craft.app.getRequest().getHeaders().has('authorization')
-  ? 'auth token present ✓' :
+  ? 'auth token present ✓'
   : 'auth token missing!' }}
 ```
 


### PR DESCRIPTION
Auth token test failed due to using two `:`'s in the ternary operator test.