### PR TITLE
Output of attr Twig function did not match in the example

### DIFF
--- a/docs/3.x/dev/functions.md
+++ b/docs/3.x/dev/functions.md
@@ -120,7 +120,7 @@ Generates a list of HTML attributes based on the given [hash](twig-primer.md#has
 Attribute values are HTML-encoded automatically:
 ```twig
 <div {{ attr({ title: 'Greetings & Salutations' }) }}></div>
-{# Output: <input type="submit" value="Greetings &amp; Salutations"> #}
+{# Output: <div title="Greetings &amp; Salutations"> #}
 ```
 :::
 

--- a/docs/4.x/dev/functions.md
+++ b/docs/4.x/dev/functions.md
@@ -123,7 +123,7 @@ Generates a list of HTML attributes based on the given [hash](twig-primer.md#has
 Attribute values are HTML-encoded automatically:
 ```twig
 <div {{ attr({ title: 'Greetings & Salutations' }) }}></div>
-{# Output: <input type="submit" value="Greetings &amp; Salutations"> #}
+{# Output: <div title="Greetings &amp; Salutations"> #}
 ```
 :::
 


### PR DESCRIPTION
### Description
The output of `attr` Twig function in the documentation did not match in the example so i changed the tag from `input` to `div` and removed the `type` attribute.


