### PR TITLE
Fixed missing `{{ csrfInput() }}` tag

### DIFF
--- a/docs/commerce/4.x/addresses.md
+++ b/docs/commerce/4.x/addresses.md
@@ -101,7 +101,8 @@ The specific properties and fields supported when updating an order’s `shippin
 
 ```twig
 <form method="post">
-  {# ... #}
+  {{ csrfInput() }}
+  {{ actionInput('commerce/cart/update-cart') }}
 
   {# Native `fullName` field: #}
   {{ input('text', 'shippingAddress[fullName]', cart.shippingAddress.fullName) }}


### PR DESCRIPTION
### Description
All other form examples start with:

```twig
<form method="post">
  {{ csrfInput() }}
```

Have updated the missing one.
