### PR TITLE
Commerce 4.3

### DIFF
--- a/docs/.vuepress/components/Since.vue
+++ b/docs/.vuepress/components/Since.vue
@@ -2,7 +2,7 @@
     <a
       class="since" 
       :href="releaseUrl"
-      :title="`${feature} was first available in version ${ver} of Craft.`"
+      :title="`${feature} was first available in version ${ver} of ${product}.`"
       target="_blank">
         {{ ver }}<span class="plus">+</span>
       </a>
@@ -16,6 +16,10 @@ export default {
   components: {},
   props: {
     ver: String,
+    product: {
+      type: String,
+      default: 'Craft',
+    },
     useChangelog: {
       type: Boolean,
       default: true,

--- a/docs/4.x/extend/README.md
+++ b/docs/4.x/extend/README.md
@@ -146,6 +146,10 @@ Any time you’re working with PHP, [PhpStorm](https://www.jetbrains.com/phpstor
 
 DDEV comes [pre-configured with xdebug](https://ddev.readthedocs.io/en/stable/users/debugging-profiling/step-debugging/), and can be connected to your IDE of choice to support breakpoints and step-debugging.
 
+#### Debug Toolbar
+
+Yii’s built-in [debug toolbar](repo:yiisoft/yii2-debug) is invaluable, especially while troubleshooting database queries, [events](events.md), and other performance issues.
+
 #### Composer
 
 If your journey with Craft so far has not involved [Composer](https://getcomposer.org), certain concepts (like namespacing and auto-loading) may present additional difficulty. Consider reviewing our article on using the [starter project](kb:using-the-starter-project), and try running [updates](../updating.md#composer) or installing a plugin with Composer.

--- a/docs/commerce/4.x/addresses.md
+++ b/docs/commerce/4.x/addresses.md
@@ -56,7 +56,7 @@ That `getStore().getStore()` is not a typo! We’re getting the <commerce4:craft
 
 ### Fetching Cart Addresses
 
-Once you have [a cart object](orders-carts.md#fetching-a-cart), you can access the attached addresses via `cart.shippingAddress` and `cart.billingAddress`:
+Once you have a [cart object](orders-carts.md#fetching-a-cart), you can access the attached addresses via `cart.shippingAddress` and `cart.billingAddress`:
 
 ```twig
 {% if cart.shippingAddress %}
@@ -72,28 +72,31 @@ Once you have [a cart object](orders-carts.md#fetching-a-cart), you can access t
 
 It’s important to code defensively, here! If the customer hasn’t set an address yet, you’ll get back `null`—otherwise, it’ll be an [Address](craft4:craft\elements\Address) object.
 
-::: tip
-You don’t need to add your own logic to handle `shippingAddressSameAsBilling` or `billingAddressSameAsShipping`; Commerce will return the correct address taking those options into account.
-:::
-
 ### Updating Cart Addresses
 
-Any post to the `commerce/cart/update-cart` action can include parameters for modifying shipping and billing address information in two formats:
+Any time you submit data to the `commerce/cart/update-cart` action, you can include parameters for modifying shipping and billing addresses:
 
-1. A `shippingAddress` and/or `billingAddress` array with details to be added (guests and logged-in users)
-2. A `shippingAddressId` and/or `billingAddressId` parameter for choosing an existing address by ID (logged-in users only)
+1. Send `shippingAddress` and/or `billingAddress` arrays with new values (guests and logged-in users);
+2. `shippingAddressId` and/or `billingAddressId` parameters for [choosing an existing address](#address-book) by ID (logged-in users only);
+3. A `shippingAddressSameAsBilling` or `billingAddressSameAsShipping` parameter to [copy address information](#synchronizing-shipping-and-billing-addresses) in one direction or another;
+
+The full list of supported parameters can be found in the [controller actions](./dev/controller-actions.md#post-cart-update-cart) documentation.
 
 #### Synchronizing Shipping and Billing Addresses
 
 With either approach, you can leverage the `shippingAddressSameAsBilling` or `billingAddressSameAsShipping` parameters to synchronize addresses and avoid having to send the same information twice.
 
-If you provide a `shippingAddress` or `shippingAddressId`, for example, and the order’s billing address should be identical, you can simply pass a non-empty value under `billingAddressSameAsShipping` rather than supplying the same `billingAddress` or `billingAddressId`.
+If you provide a `shippingAddress` or `shippingAddressId` and the order’s billing address should be identical, you can simply send a non-empty `billingAddressSameAsShipping` param rather than supplying the same `billingAddress` or `billingAddressId`.
 
-If you provide `shippingAddress` fields *and* `shippingAddressId`, the latter takes precedence.
+If you provide `shippingAddress` fields *and* a `shippingAddressId`, the latter takes precedence.
 
 ::: warning
-Commerce doesn’t require an order to have a shipping address, but providing one is important for the tax and shipping engine to calculate more accurate options and costs.
+Customize what address information is required at checkout with the [`requireBillingAddressAtCheckout`](config-settings.md#requirebillingaddressatcheckout) and [`requireShippingAddressAtCheckout`](config-settings.md#requireshippingaddressatcheckout) config settings.
+
+The tax and shipping engines require address information to generate accurate options and costs.
 :::
+
+Use the `cart.hasMatchingAddresses()` method to confirm to customers that their addresses match. Read more about how Commerce handles changes to addresses in the [address book](#auto-fill-from-address-book) section.
 
 #### Address Fields
 
@@ -118,7 +121,7 @@ For more information on address management, continue reading—or see the main C
 
 Logged-in users can directly [manage their addresses](/4.x/addresses.md#managing-addresses) via the front-end, and pick from them during checkout. However, addresses are only ever “owned” by one element—let’s look at some examples of how Commerce handles this:
 
-- When an address is selected by updating a cart with a `shippingAddressId` or `billingAddressId`, the order keeps track of where the address came from via `sourceShippingAddressId` and `sourceBillingAddressId` properties, but _clones_ the actual address element. This means that `shippingAddressId` and `sourceShippingAddressId` will never be the same!
+- When an address is selected by updating a cart with a `shippingAddressId` or `billingAddressId`, the order keeps track of where the address came from via `sourceShippingAddressId` and `sourceBillingAddressId` properties, but _clones_ the actual address element. This means that `shippingAddressId` and `sourceShippingAddressId` will _never_ be the same—even if they were filled from the same source address!
 - Addresses provided by sending individual fields under the `shippingAddress[...]` and `billingAddress[...]` keys are created and owned by the order.
 - Similarly, sending individual field values for an order’s shipping or billing address (regardless of how it was originally populated) will only update the order address, and breaks any association to the user’s address book via `sourceShippingAddressId` or `sourceBillingAddressId`.
 
@@ -176,23 +179,25 @@ Your customers can save the billing and/or shipping addresses on their cart to t
   {{ csrfInput() }}
   {{ actionInput('commerce/cart/update-cart') }}
 
+  {# ... #}
+
   {% if currentUser %}
     {% if cart.billingAddressId and not cart.sourceBillingAddressId %} 
-      {{ input('checkbox', 'saveBillingAddressOnOrderComplete', 1, {checked: cart.saveBillingAddressOnOrderComplete}) }}
+      {{ input('checkbox', 'saveBillingAddressOnOrderComplete', 1, { checked: cart.saveBillingAddressOnOrderComplete }) }}
     {% endif %}
 
     {% if cart.shippingAddressId and not cart.sourceShippingAddressId %} 
-      {{ input('checkbox', 'saveShippingAddressOnOrderComplete', 1, {checked: cart.saveShippingAddressOnOrderComplete}) }}
+      {{ input('checkbox', 'saveShippingAddressOnOrderComplete', 1, { checked: cart.saveShippingAddressOnOrderComplete }) }}
     {% endif %}
   {% endif %}
-
-  {# ... #}
 
   <button>Save Cart</button>
 </form>
 ```
 
-It is also possible to set both addresses to save by using the `saveAddressesOnOrderComplete` parameter.
+This example guards against saving an existing address, indicated by the presence of a `cart.sourceBillingAddressId` or `cart.sourceShippingAddressId`.
+
+You may also possible to save both addresses at once, by using the `saveAddressesOnOrderComplete` parameter.
 
 ```twig
 {% set cart = craft.commerce.carts.cart %}
@@ -217,7 +222,7 @@ The `saveAddress*` properties are only applicable to logged-in users who created
 
 #### Auto-fill from Address Book
 
-You can allow your customers to populate order addresses with a previously-saved one by sending a `shippingAddressId` and/or `billingAddressId` param when updating the cart.
+You can let your customers populate their cart addresses with a previously-saved one by sending a `shippingAddressId` and/or `billingAddressId` param when updating the cart.
 
 ```twig
 {% set cart = craft.commerce.carts.cart %}
@@ -249,7 +254,7 @@ You can allow your customers to populate order addresses with a previously-saved
 </form>
 ```
 
-You may need to create custom routes to allow customers to [manage these addresses](/4.x/addresses.md#managing-addresses), or introduce logic in the browser to hide and show new address forms based on the type(s) of addresses you need.
+You may need to create custom routes to allow logged-in customers to [manage these addresses](/4.x/addresses.md#managing-addresses), or introduce logic in the template or browser to hide and show new address forms based on the type(s) of addresses you need.
 
 #### Update an Existing Address
 
@@ -272,12 +277,12 @@ An address on the cart may be updated in-place by passing individual address pro
 </form>
 ```
 
-You may also send `firstName` and `lastName` properties, separately. <Since ver="4.3.0" feature="Sending discrete first and last name params" product="Commerce" />
+You may also send `firstName` and `lastName` properties, separately. <Since ver="4.3.0" feature="Sending discrete first and last name params" product="Commerce" repo="craftcms/commerce" />
 
 ::: warning
-Changes to an address in the customer’s address book (via the [`users/save-address` action](/4.x/dev/controller-actions.md#users-save-address)) _will_ be copied to any carts it was attached to.
+Changes to an address in the customer’s address book (via the [`users/save-address` action](/4.x/dev/controller-actions.md#users-save-address)) are copied to any carts it is attached to.
 
-_However_, any field(s) updated on an order address that was originally populated from the customer’s address book will _not_ propagate back to the source, and will break the association to it. Sending `shippingAddressId` and `billingAddressId` are only intended to populate an order address with existing information—not keep them synchronized.
+_However_, any field(s) updated on an order address that was originally populated from the customer’s address book will _not_ propagate back to the source, and will break the association to it. Sending `shippingAddressId` and `billingAddressId` are only intended to populate an order address with existing information, and to track where it originally came from—not bind them in both directions.
 :::
 
 ### Estimate Cart Addresses
@@ -349,6 +354,35 @@ A full example of this can be seen in the [example templates](example-templates.
 
 ## Address Book
 
-When logged in, your customers can manage their addresses independently of the cart. Refer to the main [addresses documentation](/4.x/addresses.md) for more information and examples.
+When logged in, your customers can manage their addresses independently of a cart. Refer to the main [addresses documentation](/4.x/addresses.md) and to this page’s section on [auto-filling addresses](#auto-fill-from-address-book) for more information and examples.
+
+### Primary Billing + Shipping Addresses
 
 In addition to the [natively supported](/4.x/dev/controller-actions.md#post-users-save-address) params, Commerce will look for `isPrimaryShipping` and `isPrimaryBilling`. These values determine which addresses get attached to a fresh cart when the [autoSetNewCartAddresses](./config-settings.md#autosetnewcartaddresses) option is enabled.
+
+To add support for setting default addresses, add this code to the [new address](/4.x/addresses.md#new-addresses) and/or [existing addresses](/4.x/addresses.md#existing-addresses) forms:
+
+```twig
+{# Make primary shipping address? #}
+{{ hiddenInput('isPrimaryShipping', 0) }}
+<label>
+  {{ input('checkbox', 'isPrimaryShipping', 1, {
+    checked: address.isPrimaryShipping
+  }) }}
+  Set as primary shipping address
+</label>
+
+{{ hiddenInput('isPrimaryBilling', 0) }}
+<label>
+  {{ input('checkbox', 'isPrimaryBilling', 1, {
+    checked: address.isPrimaryBilling
+  }) }}
+  Set as primary billing address
+</label>
+```
+
+::: tip
+`checkbox` inputs only send a value when checked. In order to support _un_-setting a primary billing or shipping address, you must include the hidden input _before_ the visible checkbox, in the DOM. This ensures that the falsey `0` value is sent when the checkbox is unchecked, differentiating it from simply not sending a value at all (omitting `isPrimaryShipping` or `isPrimaryBilling` entirely makes no changes to the user’s current settings).
+:::
+
+Similarly, you can send `makePrimaryBillingAddress` or `makePrimaryShippingAddress` params along with any `cart/update-cart` request to set an address attached to the cart as the customer’s primary billing or shipping address. Only addresses that retain their `sourceBillingAddressId` or `sourceShippingAddressId` can be configured this way.

--- a/docs/commerce/4.x/addresses.md
+++ b/docs/commerce/4.x/addresses.md
@@ -164,6 +164,58 @@ Customers—especially guests—will probably need to enter an address at checko
 If your request also includes a non-empty `shippingAddressId` or `billingAddressId param, the corresponding individual address fields are ignored and Commerce attempts to fill from an [existing address](#auto-fill-from-address-book).
 :::
 
+#### Saving addresses on order completion
+
+If the checkout allows and the customer has decided to, it is possible to save the billing, shipping, or both addresses to the customer’s address book after order completion.
+
+This can be achieved by using the `saveBillingAddressOnOrderComplete` and/or `saveShhippingAddressOnOrderComplete` parameters when updating the cart.
+
+```twig
+{% set cart = craft.commerce.carts.cart %}
+
+<form method="post">
+  {{ csrfInput() }}
+  {{ actionInput('commerce/cart/update-cart') }}
+  
+  {% if currentUser %}
+    {% if cart.billingAddressId and not cart.sourceBillingAddressId %} 
+      {{ input('checkbox', 'saveBillingAddressOnOrderComplete', 1, {checked: cart.saveBillingAddressOnOrderComplete}) }}
+    {% endif %}
+    
+    {% if cart.shippingAddressId and not cart.sourceShippingAddressId %} 
+      {{ input('checkbox', 'saveShippingAddressOnOrderComplete', 1, {checked: cart.saveShippingAddressOnOrderComplete}) }}
+    {% endif %}
+  {% endif %}
+
+  {# ... #}
+
+  <button>Save Cart</button>
+</form>
+```
+
+It is also possible to set both addresses to save by using the `saveAddressesOnOrderComplete` parameter.
+
+```twig
+{% set cart = craft.commerce.carts.cart %}
+
+<form method="post">
+  {{ csrfInput() }}
+  {{ actionInput('commerce/cart/update-cart') }}
+
+  {% if currentUser and ((cart.billingAddressId and not cart.sourceBillingAddressId) or (cart.shippingAddressId and not cart.sourceShippingAddressId)) %}
+    {{ input('checkbox', 'saveAddressesOnOrderComplete', 1, {checked: cart.saveBillingAddressOnOrderComplete and cart.saveShippingAddressOnOrderComplete}) }}
+  {% endif %}
+
+  {# ... #}
+
+  <button>Save Cart</button>
+</form>
+```
+
+::: tip
+The save address properties are only appropriate for logged-in users that have created addresses directly on the cart. Setting these options to `true` if the user selected an address from their address book has no effect.
+:::
+
 #### Auto-fill from Address Book
 
 You can allow your customers to populate order addresses with a previously-saved one by sending a `shippingAddressId` and/or `billingAddressId` param when updating the cart.

--- a/docs/commerce/4.x/addresses.md
+++ b/docs/commerce/4.x/addresses.md
@@ -217,7 +217,7 @@ Both properties can be set at once with the `saveAddressesOnOrderComplete` param
 ```
 
 ::: tip
-The `saveAddress*` properties are only applicable to logged-in users who created addresses directly on the cart. Setting these options to `true` if the user selected an address from their [address book](#auto-fill-from-address-book) has no effect.
+The `saveAddress*` properties are only applicable to customers who created addresses directly on the cart. Setting these options to `true` if a _registered_ customer selected an address from their [address book](#auto-fill-from-address-book) has no effect.
 
 Guests’ addresses are automatically saved to their customer account when [registering at checkout](customers.md#registration-at-checkout). <Since product="commerce" ver="4.3.0" feature="Auto-saving guest address when registering at checkout" />
 :::
@@ -388,3 +388,5 @@ To add support for setting default addresses, add this code to the [new address]
 :::
 
 Similarly, you can send `makePrimaryBillingAddress` or `makePrimaryShippingAddress` params along with any `cart/update-cart` request to set an address attached to the cart as the customer’s primary billing or shipping address. Only addresses that retain their `sourceBillingAddressId` or `sourceShippingAddressId` can be configured this way.
+
+### Address Synchronization

--- a/docs/commerce/4.x/addresses.md
+++ b/docs/commerce/4.x/addresses.md
@@ -212,7 +212,7 @@ It is also possible to set both addresses to save by using the `saveAddressesOnO
 ```
 
 ::: tip
-The save address properties are only appropriate for logged-in users that have created addresses directly on the cart. Setting these options to `true` if the user selected an address from their address book has no effect.
+The `saveAddress*` properties are only applicable to logged-in users who created addresses directly on the cart. Setting these options to `true` if the user selected an address from their [address book](#auto-fill-from-address-book) has no effect.
 :::
 
 #### Auto-fill from Address Book

--- a/docs/commerce/4.x/addresses.md
+++ b/docs/commerce/4.x/addresses.md
@@ -197,7 +197,7 @@ Your customers can save the billing and/or shipping addresses on their cart to t
 
 This example guards against saving an existing address, indicated by the presence of a `cart.sourceBillingAddressId` or `cart.sourceShippingAddressId`.
 
-You may also possible to save both addresses at once, by using the `saveAddressesOnOrderComplete` parameter.
+Both properties can be set at once with the `saveAddressesOnOrderComplete` parameter, but you are still responsible for deriving UI state from the underlying address-specific properties:
 
 ```twig
 {% set cart = craft.commerce.carts.cart %}
@@ -218,6 +218,8 @@ You may also possible to save both addresses at once, by using the `saveAddresse
 
 ::: tip
 The `saveAddress*` properties are only applicable to logged-in users who created addresses directly on the cart. Setting these options to `true` if the user selected an address from their [address book](#auto-fill-from-address-book) has no effect.
+
+Guests’ addresses are automatically saved to their customer account when [registering at checkout](customers.md#registration-at-checkout). <Since product="commerce" ver="4.3.0" feature="Auto-saving guest address when registering at checkout" />
 :::
 
 #### Auto-fill from Address Book

--- a/docs/commerce/4.x/addresses.md
+++ b/docs/commerce/4.x/addresses.md
@@ -164,11 +164,9 @@ Customers—especially guests—will probably need to enter an address at checko
 If your request also includes a non-empty `shippingAddressId` or `billingAddressId param, the corresponding individual address fields are ignored and Commerce attempts to fill from an [existing address](#auto-fill-from-address-book).
 :::
 
-#### Saving addresses on order completion
+#### Save Addresses when Completing an Order <Since ver="4.3.0" repo="craftcms/commerce" feature="Saving addresses at checkout" product="Commerce" />
 
-If the checkout allows and the customer has decided to, it is possible to save the billing, shipping, or both addresses to the customer’s address book after order completion.
-
-This can be achieved by using the `saveBillingAddressOnOrderComplete` and/or `saveShhippingAddressOnOrderComplete` parameters when updating the cart.
+Your customers can save the billing and/or shipping addresses on their cart to their address book when they check out. These options are stored as `saveBillingAddressOnOrderComplete` and `saveShippingAddressOnOrderComplete` on the cart or <commerce4:craft\commerce\elements\Order> object. You may send corresponding values any time you update the customer’s cart:
 
 ```twig
 {% set cart = craft.commerce.carts.cart %}
@@ -176,12 +174,12 @@ This can be achieved by using the `saveBillingAddressOnOrderComplete` and/or `sa
 <form method="post">
   {{ csrfInput() }}
   {{ actionInput('commerce/cart/update-cart') }}
-  
+
   {% if currentUser %}
     {% if cart.billingAddressId and not cart.sourceBillingAddressId %} 
       {{ input('checkbox', 'saveBillingAddressOnOrderComplete', 1, {checked: cart.saveBillingAddressOnOrderComplete}) }}
     {% endif %}
-    
+
     {% if cart.shippingAddressId and not cart.sourceShippingAddressId %} 
       {{ input('checkbox', 'saveShippingAddressOnOrderComplete', 1, {checked: cart.saveShippingAddressOnOrderComplete}) }}
     {% endif %}

--- a/docs/commerce/4.x/addresses.md
+++ b/docs/commerce/4.x/addresses.md
@@ -275,7 +275,9 @@ An address on the cart may be updated in-place by passing individual address pro
 You may also send `firstName` and `lastName` properties, separately. <Since ver="4.3.0" feature="Sending discrete first and last name params" product="Commerce" />
 
 ::: warning
-Any field(s) updated on an order address filled from the customer’s address book will _not_ propagate back to the source, and will break the association to it. Sending `shippingAddressId` and `billingAddressId` are only intended to populate an order address with existing information—not keep them synchronized.
+Changes to an address in the customer’s address book (via the [`users/save-address` action](/4.x/dev/controller-actions.md#users-save-address)) _will_ be copied to any carts it was attached to.
+
+_However_, any field(s) updated on an order address that was originally populated from the customer’s address book will _not_ propagate back to the source, and will break the association to it. Sending `shippingAddressId` and `billingAddressId` are only intended to populate an order address with existing information—not keep them synchronized.
 :::
 
 ### Estimate Cart Addresses

--- a/docs/commerce/4.x/addresses.md
+++ b/docs/commerce/4.x/addresses.md
@@ -272,6 +272,8 @@ An address on the cart may be updated in-place by passing individual address pro
 </form>
 ```
 
+You may also send `firstName` and `lastName` properties, separately. <Since ver="4.3.0" feature="Sending discrete first and last name params" product="Commerce" />
+
 ::: warning
 Any field(s) updated on an order address filled from the customer’s address book will _not_ propagate back to the source, and will break the association to it. Sending `shippingAddressId` and `billingAddressId` are only intended to populate an order address with existing information—not keep them synchronized.
 :::

--- a/docs/commerce/4.x/addresses.md
+++ b/docs/commerce/4.x/addresses.md
@@ -382,7 +382,7 @@ To add support for setting default addresses, add this code to the [new address]
 ```
 
 ::: tip
-`checkbox` inputs only send a value when checked. In order to support _un_-setting a primary billing or shipping address, you must include the hidden input _before_ the visible checkbox, in the DOM. This ensures that the falsey `0` value is sent when the checkbox is unchecked, differentiating it from simply not sending a value at all (omitting `isPrimaryShipping` or `isPrimaryBilling` entirely makes no changes to the user’s current settings).
+`checkbox` inputs only send a value when checked. In order to support _un_-setting a primary billing or shipping address, you must include the hidden input _before_ the visible checkbox, in the DOM. This ensures that the falsy `0` value is sent when the checkbox is unchecked, differentiating it from simply not sending a value at all (omitting `isPrimaryShipping` or `isPrimaryBilling` entirely makes no changes to the user’s current settings).
 :::
 
 Similarly, you can send `makePrimaryBillingAddress` or `makePrimaryShippingAddress` params along with any `cart/update-cart` request to set an address attached to the cart as the customer’s primary billing or shipping address. Only addresses that retain their `sourceBillingAddressId` or `sourceShippingAddressId` can be configured this way.

--- a/docs/commerce/4.x/console-commands.md
+++ b/docs/commerce/4.x/console-commands.md
@@ -3,41 +3,50 @@ keywords: cli
 ---
 # Console Commands
 
-Commerce adds console commands that can be run in your terminal.
+Commerce supplements Craft’s own [console commands](/4.x/console-commands.md) with a few utilities that can help you manage your storefront’s data.
 
-See Craft’s [Console Commands](/4.x/console-commands.md) page for more about using console commands.
+## `commerce/example-templates`
 
-## example-templates
-
-Customizes and copies example templates into your project’s template folder.
+Copies the example templates that Commerce ships with into your project’s template folder.
 
 ```
 $ php craft commerce/example-templates
 A folder will be copied to your templates directory.
 Choose folder name: [shop] myshop
-Use CDN link to resources (tailwind)? (yes|no) [yes]: yes
-Base Tailwind CSS color: [gray,red,yellow,green,blue,indigo,purple,pink,?]: green
-Attempting to copy example templates ... 
 Copying ...
 Done!
 ```
 
-## reset-data
+Pass the `--overwrite` flag if you'd like to squash an existing folder of the same name.
+
+## `commerce/reset-data`
 
 Cleanses Commerce data without uninstalling the plugin or removing store configuration. This can be useful for removing test data after finishing initial project development.
 
 Deletes all orders, subscriptions, payment sources, customers, addresses and resets discount usages.
 
 ```
-php craft commerce/reset-data
+$ php craft commerce/reset-data
 ```
 
-## upgrade
+## `commerce/transfer-user-data` <Since product="commerce" ver="4.3.0" feature="The customer data transfer command" />
 
-Support command for the Commerce 3 → Commerce 4 upgrade process, meant to be run _after_ upgrading to Commerce 4.
+Transfers customer data from one user to another. You will be prompted for the username or email of the source and destination users.
 
 ```
-php craft commerce/upgrade
+$ php craft commerce/transfer-user-data
+```
+
+::: warning
+Updates are performed via low-level database queries, so element events are not emitted and plugins are not given an opportunity to alter this behavior. This also serves to speed up the process of saving large amounts of data.
+:::
+
+## `commerce/upgrade`
+
+Support command for the Commerce 3 → Commerce 4 upgrade process; meant to be run _after_ upgrading to Commerce 4.
+
+```
+$ php craft commerce/upgrade
 ```
 
 It goes through several steps to ensure the best-possible migration:

--- a/docs/commerce/4.x/console-commands.md
+++ b/docs/commerce/4.x/console-commands.md
@@ -17,7 +17,7 @@ Copying ...
 Done!
 ```
 
-Pass the `--overwrite` flag if you'd like to squash an existing folder of the same name.
+Pass the `--overwrite` flag if you’d like to squash an existing folder of the same name.
 
 ## `commerce/reset-data`
 

--- a/docs/commerce/4.x/customers.md
+++ b/docs/commerce/4.x/customers.md
@@ -27,10 +27,6 @@ If you’d like to be able to see and manage customer addresses from the control
 
 A customer with saved login information is considered a [credentialed](/4.x/users.md#active-and-inactive-users) user. Conversely, customers who check out as guests are set up as inactive users.
 
-### Guest Checkout
-
-If someone visits the store and checks out as a guest, a new inactive user is created and related to the order—and any future orders using the same email address will be consolidated under that user.
-
 ### User Checkout <badge text="Pro" type="edition" vertical="middle">Pro</badge>
 
 Logged in customers are bound to their cart the moment it is created.
@@ -41,6 +37,10 @@ Setting | Result
 ------- | ------
 <config4:useEmailAsUsername> | Only requires an email address to register; can be pre-filled if the customer already set an email on their cart (as this creates an inactive user, behind the scenes).
 <config4:deferPublicRegistrationPassword> | A password is set only after activating their account (typically only used in combination with [email verification](/4.x/user-management.md#public-registration)).
+
+### Guest Checkout
+
+If someone visits the store and checks out as a guest, a new inactive user is created and related to the order—and any future orders using the same email address will be consolidated under that user.
 
 #### Registration at Checkout
 
@@ -62,3 +62,5 @@ If a customer chooses to register an account upon order completion, an activatio
   <button>Save cart</button>
 </form>
 ```
+
+When registering at checkout, the order’s billing and shipping [addresses](addresses.md) are automatically saved to the new accounts for future use. <Since product="commerce" ver="4.3.0" feature="Auto-saving guest address when registering at checkout" />

--- a/docs/commerce/4.x/customers.md
+++ b/docs/commerce/4.x/customers.md
@@ -48,6 +48,17 @@ You can also offer the option to initiate registration _at_ checkout by sending 
 
 If a customer chooses to register an account upon order completion, an activation link is sent to the email on file.
 
-::: tip
-The Commerce [example templates](https://github.com/craftcms/commerce/blob/main/example-templates/dist/shop/checkout/payment.twig) display a “Create an account” checkbox at the payment stage.
-:::
+```twig
+{% set cart = craft.commerce.carts.cart %}
+
+<form method="post">
+  {{ csrfInput() }}
+  {{ actionInput('commerce/cart/update-cart') }}
+
+  {{ input('checbox', 'registerUserOnOrderComplete', 1, {checked: cart.registerUserOnOrderComplete}) }}
+
+  {# ... #}
+
+  <button>Save cart</button>
+</form>
+```

--- a/docs/commerce/4.x/dev/controller-actions.md
+++ b/docs/commerce/4.x/dev/controller-actions.md
@@ -119,7 +119,7 @@ Param | Description
 `registerUserOnOrderComplete` | Whether to create a user account for the customer when the cart is completed and turned into an order.
 `saveBillingAddressOnOrderComplete` | Whether to save the billing address to the customer’s address book when the cart is completed and turned into an order.
 `saveShippingAddressOnOrderComplete` | Whether to save the shipping address to the customer’s address book when the cart is completed and turned into an order.
-`saveAddressesOnOrderComplete` | Whether to save the shipping & billing address to the customer’s address book when the cart is completed and turned into an order.
+`saveAddressesOnOrderComplete` | Whether to save both the shipping _and_ billing address to the customer’s address book when the cart is completed and turned into an order.
 `shippingAddress[]` | Shipping address attributes. (See [Addresses](../addresses.md)).
 `shippingAddressId` | ID of an existing address to use as the shipping address.
 `shippingAddressSameAsBilling` | Set to `true` to use billing address for shipping address and ignore `shippingAddress` and `shippingAddressId`.

--- a/docs/commerce/4.x/dev/controller-actions.md
+++ b/docs/commerce/4.x/dev/controller-actions.md
@@ -124,7 +124,7 @@ Param | Description
 `registerUserOnOrderComplete` | Whether to create a user account for the customer when the cart is completed and turned into an order.
 `saveBillingAddressOnOrderComplete` | Whether to save the billing address to the customer’s address book when the cart is completed and turned into an order. <Since ver="4.3.0" repo="craftcms/commerce" feature="This param" product="Commerce" />
 `saveShippingAddressOnOrderComplete` | Whether to save the shipping address to the customer’s address book when the cart is completed and turned into an order. <Since ver="4.3.0" repo="craftcms/commerce" feature="This param" product="Commerce" />
-`saveAddressesOnOrderComplete` | Whether to save both the shipping _and_ billing address to the customer’s address book when the cart is completed and turned into an order. <Since ver="4.3.0" repo="craftcms/commerce" feature="This param" product="Commerce" />
+`saveAddressesOnOrderComplete` | Whether to save both the shipping _and_ billing address to the customer’s address book when the cart is completed and turned into an order. Unlike `saveBillingAddressOnOrderComplete` and `saveShippingAddressOnOrderComplete`, this is _not_ stored on the order itself—it just allows customers to set both at the same time. <Since ver="4.3.0" repo="craftcms/commerce" feature="This param" product="Commerce" />
 `shippingAddress[]` | Shipping address attributes. (See [Addresses](../addresses.md)).
 `shippingAddressId` | ID of an existing address to use as the shipping address.
 `shippingAddressSameAsBilling` | Set to `true` to use billing address for shipping address and ignore `shippingAddress` and `shippingAddressId`.

--- a/docs/commerce/4.x/dev/controller-actions.md
+++ b/docs/commerce/4.x/dev/controller-actions.md
@@ -46,9 +46,6 @@ Param | Description
 `forceSave` | Optionally set to `true` to force saving the cart.
 `number` | Optional order number for a specific, existing cart.
 `registerUserOnOrderComplete` | Whether to create a user account for the customer when the cart is completed and turned into an order.
-`saveBillingAddressOnOrderComplete` | Whether to save the billing address to the customer’s address book when the cart is completed and turned into an order.
-`saveShippingAddressOnOrderComplete` | Whether to save the shipping address to the customer’s address book when the cart is completed and turned into an order.
-`saveAddressesOnOrderComplete` | Whether to save the shipping & billing address to the customer’s address book when the cart is completed and turned into an order.
 
 #### Response
 
@@ -255,6 +252,9 @@ Param | Description
 `paymentSourceId` | The ID for a payment source that should be used for payment.
 `registerUserOnOrderComplete` | Whether the customer should have an account created on order completion.
 `savePaymentSource` | Whether to save card information as a payment source. (Gateway must support payment sources.)
+`saveBillingAddressOnOrderComplete` | Whether to save the billing address to the customer’s address book when the cart is completed and turned into an order.
+`saveShippingAddressOnOrderComplete` | Whether to save the shipping address to the customer’s address book when the cart is completed and turned into an order.
+`saveAddressesOnOrderComplete` | Whether to save both the shipping _and_ billing address to the customer’s address book when the cart is completed and turned into an order.
 
 #### Response
 

--- a/docs/commerce/4.x/dev/controller-actions.md
+++ b/docs/commerce/4.x/dev/controller-actions.md
@@ -17,12 +17,13 @@ Action | Description
 <badge vertical="baseline" type="verb">POST</badge> [cart/complete](#post-cart-complete) | Completes an order without payment.
 <badge vertical="baseline" type="verb">GET</badge> [cart/get-cart](#get-cart-get-cart) | Returns the current cart as JSON.
 <badge vertical="baseline" type="verb">GET/POST</badge> [cart/load-cart](#get-post-cart-load-cart) | Loads a cookie for the given cart.
+<badge vertical="baseline" type="verb">POST</badge> [cart/forget-cart](#get-post-cart-forget-cart) | Loads a cookie for the given cart.
 <badge vertical="baseline" type="verb">POST</badge> [cart/update-cart](#post-cart-update-cart) | Manage a customer’s current [cart](../orders-carts.md).
-<badge vertical="baseline" type="verb">GET</badge> [downloads/pdf](#get-downloads-pdf) | Returns an order PDF as a file.
 <badge vertical="baseline" type="verb">POST</badge> [payment-sources/add](#post-payment-sources-add) | Creates a new payment source.
 <badge vertical="baseline" type="verb">POST</badge> [payment-sources/delete](#post-payment-sources-delete) | Deletes a payment source.
 <badge vertical="baseline" type="verb">GET</badge> [payments/complete-payment](#get-payments-complete-payment) | Processes customer’s return from an off-site payment.
 <badge vertical="baseline" type="verb">POST</badge> [payments/pay](#post-payments-pay) | Makes a payment on an order.
+<badge vertical="baseline" type="verb">GET</badge> [downloads/pdf](#get-downloads-pdf) | Returns an order PDF as a file.
 
 [Address management](/4.x/addresses.md/#managing-addresses) actions are part of the main Craft documentation. Commerce also allows address information to be set directly on a cart via <badge vertical="baseline" type="verb">POST</badge> [cart/update-cart](#post-cart-update-cart).
 
@@ -162,25 +163,44 @@ State | `text/html` | `application/json`
 
 </span>
 
-### <badge vertical="baseline" type="verb">GET</badge> `downloads/pdf`
+### <badge vertical="baseline" type="verb">POST</badge> `cart/forget-cart` <Since ver="4.3.0" product="craftcms/commerce" feature="Forgetting carts" />
 
-Generates and sends an order [PDF](../pdfs.md) as a file.
+Detaches a cart from the current customer’s session. Read more about [managing carts](../orders-carts.md#loading-and-forgetting-carts).
+
+This action has no arguments and responses are only sent as `text/html`.
+
+#### Response
+
+<span class="croker-table">
+
+State | `text/html`
+--- | ---
+<check-mark label="Success" /> | [Standard behavior](/4.x/dev/controller-actions.md#after-a-get-request).
+
+</span>
+
+### <badge vertical="baseline" type="verb">GET</badge> `cart/get-cart`
+
+Returns the [current cart](../orders-carts.md#fetching-a-cart) as JSON. A new cart cookie will be generated if one doesn’t already exist.
+
+The request must include `Accept: application/json` in its headers.
 
 #### Supported Params
 
 Param | Description
 ----- | -----------
-`number` | Required order number.
-`option` | Optional string value that’s passed to the PDF template.
-`pdfHandle` | Handle of a configured PDF to be rendered.
+`number` | Optional order number for a specific, existing cart.
+`forceSave` | Optionally set to `true` to force saving the cart.
 
 #### Response
 
-State | Output
------ | ------
-<check-mark label="Success" /> | File response with the rendered PDF and an `application/pdf` MIME type.
-<x-mark label="Failure" /> | Exceptions will be rendered with the normal [error template](/4.x/routing.md#error-templates).
+<span class="croker-table">
 
+State | `application/json`
+----- | ------------------
+<check-mark label="Success" /> | [Standard behavior](/4.x/dev/controller-actions.md#after-a-get-request); cart data is available under a key determined by the [cartVariable](../config-settings.md#cartvariable) config setting.
+
+</span>
 
 ### <badge vertical="baseline" type="verb">POST</badge> `payment-sources/add`
 
@@ -299,3 +319,22 @@ State | `text/html` | `application/json`
 <x-mark/> | [Standard behavior](/4.x/dev/controller-actions.md#after-a-get-request); redirection defaults to the order’s `cancelUrl`. | [Standard behavior](/4.x/dev/controller-actions.md#after-a-get-request); special `url` property set to the order’s `cancelUrl`.
 
 </span>
+
+### <badge vertical="baseline" type="verb">GET</badge> `downloads/pdf`
+
+Generates and sends an order [PDF](../pdfs.md) as a file.
+
+#### Supported Params
+
+Param | Description
+----- | -----------
+`number` | Required order number.
+`option` | Optional string value that’s passed to the PDF template.
+`pdfHandle` | Handle of a configured PDF to be rendered.
+
+#### Response
+
+State | Output
+----- | ------
+<check-mark label="Success" /> | File response with the rendered PDF and an `application/pdf` MIME type.
+<x-mark label="Failure" /> | Exceptions will be rendered with the normal [error template](/4.x/routing.md#error-templates).

--- a/docs/commerce/4.x/dev/controller-actions.md
+++ b/docs/commerce/4.x/dev/controller-actions.md
@@ -46,6 +46,9 @@ Param | Description
 `forceSave` | Optionally set to `true` to force saving the cart.
 `number` | Optional order number for a specific, existing cart.
 `registerUserOnOrderComplete` | Whether to create a user account for the customer when the cart is completed and turned into an order.
+`saveBillingAddressOnOrderComplete` | Whether to save the billing address to the customer’s address book when the cart is completed and turned into an order.
+`saveShippingAddressOnOrderComplete` | Whether to save the shipping address to the customer’s address book when the cart is completed and turned into an order.
+`saveAddressesOnOrderComplete` | Whether to save the shipping & billing address to the customer’s address book when the cart is completed and turned into an order.
 
 #### Response
 
@@ -117,6 +120,9 @@ Param | Description
 `purchasableId` | Single purchasable ID to be added to the cart. If provided, will also use optional `note`, `options[]`, and `qty` parameters.
 `purchasables[]` | Array of one or more purchasables to be [added to the cart](../orders-carts.md#adding-a-multiple-items). Each must include an `id` key-value pair, and may include `options`, `note`, and `qty` key-value pairs.
 `registerUserOnOrderComplete` | Whether to create a user account for the customer when the cart is completed and turned into an order.
+`saveBillingAddressOnOrderComplete` | Whether to save the billing address to the customer’s address book when the cart is completed and turned into an order.
+`saveShippingAddressOnOrderComplete` | Whether to save the shipping address to the customer’s address book when the cart is completed and turned into an order.
+`saveAddressesOnOrderComplete` | Whether to save the shipping & billing address to the customer’s address book when the cart is completed and turned into an order.
 `shippingAddress[]` | Shipping address attributes. (See [Addresses](../addresses.md)).
 `shippingAddressId` | ID of an existing address to use as the shipping address.
 `shippingAddressSameAsBilling` | Set to `true` to use billing address for shipping address and ignore `shippingAddress` and `shippingAddressId`.

--- a/docs/commerce/4.x/dev/controller-actions.md
+++ b/docs/commerce/4.x/dev/controller-actions.md
@@ -117,9 +117,9 @@ Param | Description
 `purchasableId` | Single purchasable ID to be added to the cart. If provided, will also use optional `note`, `options[]`, and `qty` parameters.
 `purchasables[]` | Array of one or more purchasables to be [added to the cart](../orders-carts.md#adding-a-multiple-items). Each must include an `id` key-value pair, and may include `options`, `note`, and `qty` key-value pairs.
 `registerUserOnOrderComplete` | Whether to create a user account for the customer when the cart is completed and turned into an order.
-`saveBillingAddressOnOrderComplete` | Whether to save the billing address to the customer’s address book when the cart is completed and turned into an order.
-`saveShippingAddressOnOrderComplete` | Whether to save the shipping address to the customer’s address book when the cart is completed and turned into an order.
-`saveAddressesOnOrderComplete` | Whether to save both the shipping _and_ billing address to the customer’s address book when the cart is completed and turned into an order.
+`saveBillingAddressOnOrderComplete` | Whether to save the billing address to the customer’s address book when the cart is completed and turned into an order. <Since ver="4.3.0" repo="craftcms/commerce" feature="This param" product="Commerce" />
+`saveShippingAddressOnOrderComplete` | Whether to save the shipping address to the customer’s address book when the cart is completed and turned into an order. <Since ver="4.3.0" repo="craftcms/commerce" feature="This param" product="Commerce" />
+`saveAddressesOnOrderComplete` | Whether to save both the shipping _and_ billing address to the customer’s address book when the cart is completed and turned into an order. <Since ver="4.3.0" repo="craftcms/commerce" feature="This param" product="Commerce" />
 `shippingAddress[]` | Shipping address attributes. (See [Addresses](../addresses.md)).
 `shippingAddressId` | ID of an existing address to use as the shipping address.
 `shippingAddressSameAsBilling` | Set to `true` to use billing address for shipping address and ignore `shippingAddress` and `shippingAddressId`.
@@ -252,9 +252,9 @@ Param | Description
 `paymentSourceId` | The ID for a payment source that should be used for payment.
 `registerUserOnOrderComplete` | Whether the customer should have an account created on order completion.
 `savePaymentSource` | Whether to save card information as a payment source. (Gateway must support payment sources.)
-`saveBillingAddressOnOrderComplete` | Whether to save the billing address to the customer’s address book when the cart is completed and turned into an order.
-`saveShippingAddressOnOrderComplete` | Whether to save the shipping address to the customer’s address book when the cart is completed and turned into an order.
-`saveAddressesOnOrderComplete` | Whether to save both the shipping _and_ billing address to the customer’s address book when the cart is completed and turned into an order.
+`saveBillingAddressOnOrderComplete` | Whether to save the billing address to the customer’s address book when the cart is completed and turned into an order. <Since ver="4.3.0" repo="craftcms/commerce" feature="This param" product="Commerce" />
+`saveShippingAddressOnOrderComplete` | Whether to save the shipping address to the customer’s address book when the cart is completed and turned into an order. <Since ver="4.3.0" repo="craftcms/commerce" feature="This param" product="Commerce" />
+`saveAddressesOnOrderComplete` | Whether to save both the shipping _and_ billing address to the customer’s address book when the cart is completed and turned into an order. <Since ver="4.3.0" repo="craftcms/commerce" feature="This param" product="Commerce" />
 
 #### Response
 

--- a/docs/commerce/4.x/dev/controller-actions.md
+++ b/docs/commerce/4.x/dev/controller-actions.md
@@ -24,6 +24,7 @@ Action | Description
 <badge vertical="baseline" type="verb">GET</badge> [payments/complete-payment](#get-payments-complete-payment) | Processes customer’s return from an off-site payment.
 <badge vertical="baseline" type="verb">POST</badge> [payments/pay](#post-payments-pay) | Makes a payment on an order.
 <badge vertical="baseline" type="verb">GET</badge> [downloads/pdf](#get-downloads-pdf) | Returns an order PDF as a file.
+<badge vertical="baseline" type="verb">POST</badge> [subscriptions/subscribe](#post-subscriptions-subscribe) | Starts a new subscription.
 
 [Address management](/4.x/addresses.md/#managing-addresses) actions are part of the main Craft documentation. Commerce also allows address information to be set directly on a cart via <badge vertical="baseline" type="verb">POST</badge> [cart/update-cart](#post-cart-update-cart).
 
@@ -338,3 +339,27 @@ State | Output
 ----- | ------
 <check-mark label="Success" /> | File response with the rendered PDF and an `application/pdf` MIME type.
 <x-mark label="Failure" /> | Exceptions will be rendered with the normal [error template](/4.x/routing.md#error-templates).
+
+### <badge vertical="baseline" type="verb">POST</badge> `subscriptions/subscribe`
+
+Starts a new subscription with the current customer’s default payment source. Learn more about supporting [Subscriptions](../subscriptions.md).
+
+#### Supported Params
+
+Param | Description
+----- | -----------
+`planUid` | **Required.** UID of the Commerce plan the customer wants to subscribe to.
+`fields[...]` | Subscription custom field values, indexed by their handles.
+`fieldsLocation` | Allows relocation of the default `fields` key for custom field data (see above).
+`*` | **Conditionally required.** Each [gateway](../payment-gateways.md) that supports subscriptions may determine additional properties that must set on its <commerce4:craft\commerce\models\SubscriptionForm>.
+
+::: warning
+`planUid` and all gateway-specific properties must be [hashed](/4.x/dev/filters.md#hash) to prevent tampering.
+:::
+
+#### Response
+
+State | Output
+----- | ------
+<check-mark label="Success" /> | File response with the rendered PDF and an `application/pdf` MIME type.
+<x-mark label="Failure" /> | Most subscription failures will be presented as a succinct error message. Specific issues are logged, but may not be disclosed to the customer.

--- a/docs/commerce/4.x/dev/controller-actions.md
+++ b/docs/commerce/4.x/dev/controller-actions.md
@@ -163,7 +163,7 @@ State | `text/html` | `application/json`
 
 </span>
 
-### <badge vertical="baseline" type="verb">POST</badge> `cart/forget-cart` <Since ver="4.3.0" product="craftcms/commerce" feature="Forgetting carts" />
+### <badge vertical="baseline" type="verb">POST</badge> `cart/forget-cart` <Since ver="4.3.0" product="Commerce" repo="craftcms/commerce" feature="Forgetting carts" />
 
 Detaches a cart from the current customer’s session. Read more about [managing carts](../orders-carts.md#loading-and-forgetting-carts).
 

--- a/docs/commerce/4.x/discounts.md
+++ b/docs/commerce/4.x/discounts.md
@@ -24,31 +24,47 @@ For more on coupon code setup and templating, see the [coupon codes](coupon-code
 
 ## Discount Matching Items
 
-Each discount’s **Matching Items** tab provides options for limiting what store items qualify for the discount. By default, all purchasables and categories may qualify for the discount.
+Each discount’s **Matching Items** tab provides options for limiting what store items qualify for the discount. By default, _all purchasables_ qualify for the discount.
 
 ### Purchasables
 
-The **All purchsables** lightswitch is on by default, but you can switch it off to select zero or more **Product Variant** relationships. Be careful with this, because switching off **All purchasables** and not selecting any variants will result in no variants qualifying for the discount!
+You can restrict a discount to specific purchasables by enabling the **Only match certain purchasables…** option, and selecting one or more via the revealed element picker(s). Each registered purchasable type will display its own selection field—but by default, this is only variants.
+
+If this is enabled and no purchasables are selected, the discount will never match.
 
 ::: tip
-Only _promotable_ purchasables may have discounts and sales applied. This means the **Promotable** switch must be enabled on the variant’s product in the control panel, which is the default for any new product.
+Only variants belonging to _promotable_ products may have discounts and sales applied. This means the **Promotable** switch must be enabled on the variant’s product in the control panel, which is the default for any new product.
 :::
 
-### Categories
+### Relationships
 
-The **Categories** lightswitch is also on by default, but you can switch it off to select zero or more product categories that should qualify for the discount. Just like the purchasables switch above, you should be sure to designate categories if the **All categories** lightswitch is disabled—otherwise it won’t be possible for any items to match the discount.
+Oftentimes, it makes more sense to make discounts available based on categories or other taxonomies than on specific products.
 
-### Advanced
+Let’s assume your store is organized into departments that are defined by a [category group](/4.x/categories.md) or [entry section](/4.x/entries.md). On each product (or variant), administrators select one or more of those departments via a category or entry custom fields.
 
-You can click the “Advanced” toggle to display a **Categories Relationship Type** field that determines how related purchasables and categories should behave matching items. Options:
-
-- **Either (Default)** – the relationship field is on the purchasable or the category
-- **Source** – the category relationship field is on the purchasable
-- **Target** – the purchasable relationship field is on the category
+In the **Matching Items** tab, enabling **Only match purchasables related to…** will reveal two element selection fields (one for categories and one for entries), as well as an [Advanced](#advanced) drawer, which allows you to specify the [direction](/4.x/relations.md#sources-and-targets) of the relationship. If you enable the relational criteria and don't select any categories or entries
 
 ::: tip
-This behavior is consistent with all Craft’s relationships; see the [Terminology](/4.x/relations.html#terminology) section on the Relations page.
+The **Categories** field will only be displayed if you have a category group configured; similarly, the **Entries** field will only be displayed if you’ve configured a section.
 :::
+
+#### Advanced
+
+The “Advanced” drawer contains the **Relationship Type** field that determines how related purchasables should behave when matching items.
+
+- **Either way (Default)**: the relational field can be on the purchasable _or_ the category/entry (the purchasable may be the source _or_ target of the relationship);
+- **The purchasable defines the relationship**: the relational field is defined on the _purchasable_, and you select categories or entries from it (the purchasable is the _source_ of the relationship);
+- **The purchasable is related by another element**: the relational field is defined on the category/entry, and you select purchasables from it (the purchasable is the _target_ of the relationship);
+
+::: tip
+This behavior is consistent with all Craft’s relationships; see the [Terminology](/4.x/relations.html#terminology) section on the Relations page for more information on sources and targets.
+:::
+
+To illustrate, suppose the “departments” we mentioned earlier each represent a landing page. Those pages (managed as entries in Craft) are also be used to organize products, through an [entries field](/4.x/entries-field.md) in the product type’s field layout. As products are added and edited, administrators place them in departments by selecting those entries as relations. In this scenario, both the **Either way** and **The purchasable defines the relationship** settings would allow the discount to match a department entry selected in its purchasable-matching rules.
+
+Now, if you were to add a “Featured Products” field to the department landing pages and select a few products, the third **The purchasable is related by another element** relationship type setting would match.
+
+This combination of settings can provide powerful matching criteria all on their own. You can even define back-end-only taxonomies (without content or URLs) for the express purpose of managing pricing rules.
 
 ## Discount Conditions Rules
 

--- a/docs/commerce/4.x/example-objects/order.php
+++ b/docs/commerce/4.x/example-objects/order.php
@@ -35,6 +35,8 @@ array (
   'shippingMethodName' => 'Free Shipping',
   'customerId' => '3',
   'registerUserOnOrderComplete' => NULL,
+  'saveBillingAddressOnOrderComplete' => NULL,
+  'saveShippingAddressOnOrderComplete' => NULL,
   'paymentSourceId' => NULL,
   'storedTotalPrice' => '30.0000',
   'storedTotalPaid' => '30.0000',

--- a/docs/commerce/4.x/example-templates.md
+++ b/docs/commerce/4.x/example-templates.md
@@ -1,23 +1,29 @@
 # Example Templates
 
-Commerce includes example templates you can use for a reference or starting point building your store.
+Commerce includes example templates you can use for a reference, or as a starting point when building your store. They are continually updated to support the full range of Commerce features, out-of-the-box, including:
 
-The examples include a robust set of templates that do pretty much everything with Commerce. This includes a full checkout flow, address handling, order management, subscription management, and cart management.
+- Cart management;
+- Complete checkout flow;
+- [Address management](/4.x/addresses.md#managing-addresses)
+- Order history;
+- Subscription management;
 
-The [`commerce/example-templates` console command](console-commands.md#example-templates) offers a quick way to customize the templates and copy them into your project, but you can also browse the templates built with default options in `vendor/craftcms/commerce/example-templates/dist/`.
+…and more!
 
-You can copy these built templates directly to your project’s top level `templates/` folder:
+Use the [`commerce/example-templates` console command](console-commands.md#example-templates) to install the example templates into your project. Those templates are always available for reference, in `vendor/craftcms/commerce/example-templates/dist/`.
+
+You can manually copy some or all of the templates into your project’s top level `templates/` folder:
 
 ```bash
 cp -r vendor/craftcms/commerce/example-templates/dist/* ./templates
 ```
 
-If your system supports it, you could also symlink these folders into your project’s `templates/` folder so you always have up-to-date examples _while in development_:
+## Plugin Development and Reference
+
+If your system supports it, you can symlink these folders into your project’s `templates/` folder so you always have up-to-date examples:
 
 ```bash
 ln -s vendor/craftcms/commerce/example-templates/dist/shop ./templates/shop
 ```
 
-::: tip
-You can also visit [craftcms.com/demo](https://craftcms.com/demo) to spin up the Spoke & Chain Craft Commerce demo. The source code is available at [github.com/craftcms/spoke-and-chain](https://github.com/craftcms/spoke-and-chain).
-:::
+This is only recommended for active development—say, when frequently pulling in unreleased versions of Commerce to test a gateway plugin.

--- a/docs/commerce/4.x/extend/events.md
+++ b/docs/commerce/4.x/extend/events.md
@@ -1810,7 +1810,7 @@ Event::on(
 If the purchasable becomes unavailable after being added to the cart, an [order notice](../orders-carts.md#order-notices) will be added to the order informing the customer.
 :::
 
-#### `modifyPurchasablesTableQuery`
+#### `modifyPurchasablesTableQuery` <Since ver="4.3.0" repo="craftcms/commerce" feature="This event" />
 
 The event that is triggered retrieving the list of purchasables for the add a line item feature on the order edit page.
 

--- a/docs/commerce/4.x/extend/events.md
+++ b/docs/commerce/4.x/extend/events.md
@@ -1,16 +1,26 @@
+---
+sidebarDepth: 2
+---
+
 # Events
 
-Craft Commerce provides a multitude of events for extending its functionality. Modules and plugins can [register event listeners](https://craftcms.com/knowledge-base/custom-module-events), typically in their `init()` methods, to modify Commerce’s behavior.
+Craft Commerce provides a multitude of events for extending its functionality. Modules and plugins can [register event listeners](/4.x/extend/events.md), typically in their `init()` methods, to modify Commerce’s behavior.
 
 ## Event Code Generator
 
-Select an event for details and a code snippet. See Craft’s [Events](/4.x/extend/events.md) page for Craft and Yii events.
+Select an event for details and a code snippet, or check out the sections below for some use cases. See Craft’s [Events](/4.x/extend/events.md) page for more information about working with events.
 
 <event-browser source="commerce-4" />
 
-## Variant Events
+## Common Events + Workflows
 
-### `beforeCaptureVariantSnapshot`
+The following sections highlight a few of the events emitted by Commerce classes. It is not exhaustive—meaning you may need to enlist the help of one or more [development tools](/4.x/extend/README.md#tools) to aid in [discovering the “right” event](/4.x/extend/events.md#discovering-events)!
+
+### Product + Variant Events
+
+[Products and variants](../products-variants.md) are [elements](/4.x/extend/element-types.md), so all the standard lifecycle events (for elements and their associated query classes) apply here.
+
+#### `beforeCaptureVariantSnapshot`
 
 The event that is triggered before a variant’s field data is captured, which makes it possible to customize which fields are included in the snapshot. Custom fields are not included by default.
 
@@ -27,7 +37,7 @@ Event::on(
     function(CustomizeVariantSnapshotFieldsEvent $event) {
         // @var Variant $variant
         $variant = $event->variant;
-        // @var array|null $fields
+        // @var string[]|null $fields
         $fields = $event->fields;
 
         // Add every custom field to the snapshot
@@ -46,7 +56,7 @@ Event::on(
 Add with care! A huge amount of custom fields/data will increase your database size.
 :::
 
-### `afterCaptureVariantSnapshot`
+#### `afterCaptureVariantSnapshot`
 
 The event that is triggered after a variant’s field data is captured. This makes it possible to customize, extend, or redact the data to be persisted on the variant instance.
 
@@ -70,7 +80,7 @@ Event::on(
 );
 ```
 
-### `beforeCaptureProductSnapshot`
+#### `beforeCaptureProductSnapshot`
 
 The event that is triggered before a product’s field data is captured. This makes it possible to customize which fields are included in the snapshot. Custom fields are not included by default.
 
@@ -107,7 +117,7 @@ Event::on(
 Add with care! A huge amount of custom fields/data will increase your database size.
 :::
 
-### `afterCaptureProductSnapshot`
+#### `afterCaptureProductSnapshot`
 
 The event that is triggered after a product’s field data is captured, which can be used to customize, extend, or redact the data to be persisted on the product instance.
 
@@ -132,9 +142,9 @@ Event::on(
 );
 ```
 
-## Sale Events
+### Sale Events
 
-### `beforeMatchPurchasableSale`
+#### `beforeMatchPurchasableSale`
 
 The event that is triggered before Commerce attempts to match a sale to a purchasable.
 
@@ -165,7 +175,7 @@ Event::on(
 );
 ```
 
-### `beforeSaveSale`
+#### `beforeSaveSale`
 
 The event that is triggered before a sale is saved.
 
@@ -188,7 +198,7 @@ Event::on(
 );
 ```
 
-### `afterSaveSale`
+#### `afterSaveSale`
 
 The event that is triggered after a sale is saved.
 
@@ -211,7 +221,7 @@ Event::on(
 );
 ```
 
-### `afterDeleteSale`
+#### `afterDeleteSale`
 
 The event that is triggered after a sale is deleted.
 
@@ -235,9 +245,9 @@ Event::on(
 
 ```
 
-## Order Events
+### Order Events
 
-### `beforeAddLineItemToOrder`
+#### `beforeAddLineItemToOrder`
 
 The event that is triggered before a new line item has been added to the order.
 
@@ -262,7 +272,7 @@ Event::on(
 );
 ```
 
-### `afterAddLineItemToOrder`
+#### `afterAddLineItemToOrder`
 
 The event that is triggered after a line item has been added to an order.
 
@@ -284,7 +294,7 @@ Event::on(
     }
 );
 ```
-### `afterApplyAddLineItemToOrder`
+#### `afterApplyAddLineItemToOrder`
 
 The event that is triggered after a line item has been added to an order.
 
@@ -306,7 +316,7 @@ Event::on(
 );
 ```
 
-### `afterRemoveLineItemToOrder`
+#### `afterRemoveLineItemToOrder`
 
 The event that is triggered after a line item has been removed from an order.
 
@@ -329,7 +339,7 @@ Event::on(
 );
 ```
 
-### `afterApplyRemoveLineItemFromOrder`
+#### `afterApplyRemoveLineItemFromOrder`
 
 The event that is triggered after a line item has been removed from an order.
 
@@ -351,7 +361,7 @@ Event::on(
 );
 ```
 
-### `beforeCompleteOrder`
+#### `beforeCompleteOrder`
 
 The event that is triggered before an order is completed.
 
@@ -370,7 +380,7 @@ Event::on(
 );
 ```
 
-### `afterCompleteOrder`
+#### `afterCompleteOrder`
 
 The event that is triggered after an order is completed.
 
@@ -389,7 +399,7 @@ Event::on(
 );
 ```
 
-### `afterOrderAuthorized`
+#### `afterOrderAuthorized`
 
 This event is raised after an order is authorized in full and completed.
 
@@ -410,7 +420,7 @@ Event::on(
 );
 ```
 
-### `afterOrderPaid`
+#### `afterOrderPaid`
 
 The event that is triggered after an order is paid and completed.
 
@@ -429,43 +439,7 @@ Event::on(
 );
 ```
 
-### `registerOrderAdjusters`
-
-The event that is triggered for registration of additional adjusters.
-
-```php
-use craft\events\RegisterComponentTypesEvent;
-use craft\commerce\services\OrderAdjustments;
-use yii\base\Event;
-
-Event::on(
-    OrderAdjustments::class,
-    OrderAdjustments::EVENT_REGISTER_ORDER_ADJUSTERS,
-    function(RegisterComponentTypesEvent $event) {
-        $event->types[] = MyAdjuster::class;
-    }
-);
-```
-
-### `registerDiscountAdjusters`
-
-The event that is triggered for registration of additional discount adjusters.
-
-```php
-use craft\events\RegisterComponentTypesEvent;
-use craft\commerce\services\OrderAdjustments;
-use yii\base\Event;
-
-Event::on(
-    OrderAdjustments::class,
-    OrderAdjustments::EVENT_REGISTER_DISCOUNT_ADJUSTERS,
-    function(RegisterComponentTypesEvent $event) {
-        $event->types[] = MyAdjuster::class;
-    }
-);
-```
-
-### `orderStatusChange`
+#### `orderStatusChange`
 
 The event that is triggered when an order status is changed.
 
@@ -491,7 +465,7 @@ Event::on(
 );
 ```
 
-### `defaultOrderStatus`
+#### `defaultOrderStatus`
 
 The event that is triggered when a default order status is being fetched.
 
@@ -519,7 +493,25 @@ Event::on(
 );
 ```
 
-### `modifyCartInfo`
+#### `registerOrderAdjusters`
+
+The event that is triggered for registration of additional adjusters.
+
+```php
+use craft\events\RegisterComponentTypesEvent;
+use craft\commerce\services\OrderAdjustments;
+use yii\base\Event;
+
+Event::on(
+    OrderAdjustments::class,
+    OrderAdjustments::EVENT_REGISTER_ORDER_ADJUSTERS,
+    function(RegisterComponentTypesEvent $event) {
+        $event->types[] = MyAdjuster::class;
+    }
+);
+```
+
+#### `modifyCartInfo`
 
 The event that’s triggered when a cart is returned as an array for Ajax cart update requests.
 
@@ -539,9 +531,9 @@ Event::on(
 );
 ```
 
-## Discount Events
+### Discount Events
 
-### `afterDiscountAdjustmentsCreated`
+#### `afterDiscountAdjustmentsCreated`
 
 The event that is triggered after a discount has matched the order and before it returns its adjustments.
 
@@ -570,7 +562,7 @@ Event::on(
 );
 ```
 
-### `beforeSaveDiscount`
+#### `beforeSaveDiscount`
 
 The event that is triggered before a discount is saved.
 
@@ -595,7 +587,7 @@ Event::on(
 );
 ```
 
-### `afterSaveDiscount`
+#### `afterSaveDiscount`
 
 The event that is triggered after a discount is saved.
 
@@ -620,7 +612,7 @@ Event::on(
 );
 ```
 
-### `afterDeleteDiscount`
+#### `afterDeleteDiscount`
 
 The event that is triggered after a discount is deleted.
 
@@ -643,7 +635,7 @@ Event::on(
 );
 ```
 
-### `discountMatchesLineItem`
+#### `discountMatchesLineItem`
 
 The event that is triggered when a line item is matched with a discount.
 
@@ -673,7 +665,7 @@ Event::on(
 );
 ```
 
-### `discountMatchesOrder`
+#### `discountMatchesOrder`
 
 The event that is triggered when an order is matched with a discount.
 
@@ -701,9 +693,9 @@ Event::on(
 );
 ```
 
-## Line Item Events
+### Line Item Events
 
-### `beforeSaveLineItem`
+#### `beforeSaveLineItem`
 
 The event that is triggered before a line item is saved.
 
@@ -728,7 +720,7 @@ Event::on(
 );
 ```
 
-### `afterSaveLineItem`
+#### `afterSaveLineItem`
 
 The event that is triggeredd after a line item is saved.
 
@@ -753,7 +745,7 @@ Event::on(
 );
 ```
 
-### `populateLineItem`
+#### `populateLineItem`
 
 The event that is triggered as a line item is being populated from a purchasable.
 
@@ -784,7 +776,7 @@ Event::on(
 Don’t forget to set `salePrice` accordingly since it’s the amount that gets added to the cart.
 :::
 
-### `createLineItem`
+#### `createLineItem`
 
 The event that is triggered after a line item has been created from a purchasable.
 
@@ -809,7 +801,7 @@ Event::on(
 );
 ```
 
-### `defaultLineItemStatus`
+#### `defaultLineItemStatus`
 
 The event that is triggered when getting a default status for a line item.
 
@@ -839,9 +831,9 @@ Event::on(
 );
 ```
 
-## Payment Events
+### Payment Events
 
-### `registerGatewayTypes`
+#### `registerGatewayTypes`
 
 The event that is triggered for the registration of additional gateways.
 
@@ -861,7 +853,7 @@ Event::on(
 );
 ```
 
-### `afterPaymentTransaction`
+#### `afterPaymentTransaction`
 
 The event that is triggered after a payment transaction is made.
 
@@ -885,7 +877,7 @@ Event::on(
 );
 ```
 
-### `beforeCaptureTransaction`
+#### `beforeCaptureTransaction`
 
 The event that is triggered before a payment transaction is captured.
 
@@ -908,7 +900,7 @@ Event::on(
 );
 ```
 
-### `afterCaptureTransaction`
+#### `afterCaptureTransaction`
 
 The event that is triggered after a payment transaction is captured.
 
@@ -931,7 +923,7 @@ Event::on(
 );
 ```
 
-### `beforeRefundTransaction`
+#### `beforeRefundTransaction`
 
 The event that is triggered before a transaction is refunded.
 
@@ -953,7 +945,7 @@ Event::on(
 );
 ```
 
-### `afterRefundTransaction`
+#### `afterRefundTransaction`
 
 The event that is triggered after a transaction is refunded.
 
@@ -975,7 +967,7 @@ Event::on(
 );
 ```
 
-### `beforeProcessPaymentEvent`
+#### `beforeProcessPaymentEvent`
 
 The event that is triggered before a payment is processed.
 
@@ -1009,7 +1001,7 @@ Event::on(
 );
 ```
 
-### `afterProcessPaymentEvent`
+#### `afterProcessPaymentEvent`
 
 The event that is triggered after a payment is processed.
 
@@ -1041,7 +1033,7 @@ Event::on(
 );
 ```
 
-### `deletePaymentSource`
+#### `deletePaymentSource`
 
 The event that is triggered when a payment source is deleted.
 
@@ -1064,7 +1056,7 @@ Event::on(
 );
 ```
 
-### `beforeSavePaymentSource`
+#### `beforeSavePaymentSource`
 
 The event that is triggered before a payment source is added.
 
@@ -1086,7 +1078,7 @@ Event::on(
 );
 ```
 
-### `afterSavePaymentSource`
+#### `afterSavePaymentSource`
 
 The event that is triggered after a payment source is added.
 
@@ -1109,7 +1101,7 @@ Event::on(
 );
 ```
 
-### `afterSaveTransaction`
+#### `afterSaveTransaction`
 
 The event that is triggered after a transaction has been saved.
 
@@ -1132,7 +1124,7 @@ Event::on(
 );
 ```
 
-### `afterCreateTransaction`
+#### `afterCreateTransaction`
 
 The event that is triggered after a transaction has been created.
 
@@ -1155,9 +1147,9 @@ Event::on(
 );
 ```
 
-## Subscription Events
+### Subscription Events
 
-### `afterExpireSubscription`
+#### `afterExpireSubscription`
 
 The event that is triggered after a subscription has expired.
 
@@ -1180,7 +1172,7 @@ Event::on(
 );
 ```
 
-### `beforeCreateSubscription`
+#### `beforeCreateSubscription`
 
 The event that is triggered before a subscription is created.
 
@@ -1211,7 +1203,7 @@ Event::on(
 );
 ```
 
-### `afterCreateSubscription`
+#### `afterCreateSubscription`
 
 The event that is triggered after a subscription is created.
 
@@ -1243,7 +1235,7 @@ Event::on(
 Since a subscription may be suspended at creation due to payment issues, you may want to check subscription properties like `hasStarted` or `isSuspended` before taking further action.
 :::
 
-### `beforeReactivateSubscription`
+#### `beforeReactivateSubscription`
 
 The event that is triggered before a subscription gets reactivated.
 
@@ -1268,7 +1260,7 @@ Event::on(
 );
 ```
 
-### `afterReactivateSubscription`
+#### `afterReactivateSubscription`
 
 The event that is triggered after a subscription gets reactivated.
 
@@ -1291,7 +1283,7 @@ Event::on(
 );
 ```
 
-### `beforeSwitchSubscriptionPlan`
+#### `beforeSwitchSubscriptionPlan`
 
 The event that is triggered before a subscription is switched to a different plan.
 
@@ -1324,7 +1316,7 @@ Event::on(
 );
 ```
 
-### `afterSwitchSubscriptionPlan`
+#### `afterSwitchSubscriptionPlan`
 
 The event that is triggered after a subscription gets switched to a different plan.
 
@@ -1355,7 +1347,7 @@ Event::on(
 );
 ```
 
-### `beforeCancelSubscription`
+#### `beforeCancelSubscription`
 
 The event that is triggered before a subscription is canceled.
 
@@ -1383,7 +1375,7 @@ Event::on(
 );
 ```
 
-### `afterCancelSubscription`
+#### `afterCancelSubscription`
 
 The event that is triggered after a subscription gets canceled.
 
@@ -1409,7 +1401,7 @@ Event::on(
 );
 ```
 
-### `beforeUpdateSubscription`
+#### `beforeUpdateSubscription`
 
 The event that is triggered before a subscription gets updated. Typically this event is fired when subscription data is updated on the gateway.
 
@@ -1431,7 +1423,7 @@ Event::on(
 );
 ```
 
-### `receiveSubscriptionPayment`
+#### `receiveSubscriptionPayment`
 
 The event that is triggered when a subscription payment is received.
 
@@ -1460,9 +1452,9 @@ Event::on(
 );
 ```
 
-## Other Events
+### Mail Events
 
-### `beforeSendEmail`
+#### `beforeSendEmail`
 
 The event that is triggered before an email is sent out.
 
@@ -1497,7 +1489,7 @@ Event::on(
 );
 ```
 
-### `afterSendEmail`
+#### `afterSendEmail`
 
 The event that is triggered after an email has been sent out.
 
@@ -1529,7 +1521,7 @@ Event::on(
 );
 ```
 
-### `beforeSaveEmail`
+#### `beforeSaveEmail`
 
 The event that is triggered before an email is saved.
 
@@ -1553,7 +1545,7 @@ Event::on(
 );
 ```
 
-### `afterSaveEmail`
+#### `afterSaveEmail`
 
 The event that is triggered after an email is saved.
 
@@ -1577,7 +1569,7 @@ Event::on(
 );
 ```
 
-### `beforeDeleteEmail`
+#### `beforeDeleteEmail`
 
 The event that is triggered before an email is deleted.
 
@@ -1599,7 +1591,7 @@ Event::on(
 );
 ```
 
-### `afterDeleteEmail`
+#### `afterDeleteEmail`
 
 The event that is triggered after an email is deleted.
 
@@ -1621,7 +1613,9 @@ Event::on(
 );
 ```
 
-### `beforeRenderPdf`
+### PDF Events
+
+#### `beforeRenderPdf`
 
 The event that is triggered before an order’s PDF is rendered.
 
@@ -1636,14 +1630,14 @@ Event handlers can customize PDF rendering by modifying several properties on th
 | `pdf`       | `null` by default, can optionally be used to supply your own PDF string rather than the one Commerce would generate |
 
 ```php
-use craft\commerce\events\PdfEvent;
+use craft\commerce\events\PdfRenderEvent;
 use craft\commerce\services\Pdfs;
 use yii\base\Event;
 
 Event::on(
     Pdfs::class,
     Pdfs::EVENT_BEFORE_RENDER_PDF,
-    function(PdfEvent $event) {
+    function(PdfRenderEvent $event) {
         // Modify `$event->order`, `$event->option`, `$event->template`,
         // and `$event->variables` to customize what gets rendered into a PDF;
         // or render your own PDF and set its string on `$event->pdf`
@@ -1656,32 +1650,32 @@ Event::on(
 If you provide your own PDF string, Commerce will skip its own rendering and [`afterRenderPdf`](#afterrenderpdf) will not be triggered.
 :::
 
-### `afterRenderPdf`
+#### `afterRenderPdf`
 
 The event that is triggered after an order’s PDF has been rendered by Commerce.
 
 Event handlers can override Commerce’s PDF generation by setting the `pdf` property on the event to a custom-rendered PDF string. The event properties will be the same as those from `beforeRenderPdf`, but `pdf` will contain a rendered PDF string and is the only one for which setting a value will make any difference for the resulting PDF output.
 
 ```php
-use craft\commerce\events\PdfEvent;
+use craft\commerce\events\PdfRenderEvent;
 use craft\commerce\services\Pdfs;
 use yii\base\Event;
 
 Event::on(
     Pdfs::class,
     Pdfs::EVENT_AFTER_RENDER_PDF,
-    function(PdfEvent $event) {
+    function(PdfRenderEvent $event) {
         // Add a watermark to the PDF or forward it to the accounting department
         // ...
     }
 );
 ```
-### `beforeSavePdf`
+#### `beforeSavePdf`
 
-The event that is triggered before a PDF is saved.
+The event that is triggered before a PDF’s configuration is saved.
 
 ```php
-use craft\commerce\events\PdfSaveEvent;
+use craft\commerce\events\PdfEvent;
 use craft\commerce\services\Pdfs;
 use craft\commerce\models\Pdf;
 use yii\base\Event;
@@ -1689,7 +1683,7 @@ use yii\base\Event;
 Event::on(
     Pdfs::class,
     Pdfs::EVENT_BEFORE_SAVE_PDF,
-    function(PdfSaveEvent $event) {
+    function(PdfEvent $event) {
         // @var Pdf $pdf
         $pdf = $event->pdf;
         // @var bool $isNew
@@ -1699,12 +1693,12 @@ Event::on(
 );
 ```
 
-### `afterSavePdf`
+#### `afterSavePdf`
 
-The event that is triggered after a PDF is saved.
+The event that is triggered after a PDF’s configuration is saved.
 
 ```php
-use craft\commerce\events\PdfSaveEvent;
+use craft\commerce\events\PdfEvent;
 use craft\commerce\services\Pdfs;
 use craft\commerce\models\Pdf;
 use yii\base\Event;
@@ -1712,7 +1706,7 @@ use yii\base\Event;
 Event::on(
     Pdfs::class,
     Pdfs::EVENT_AFTER_SAVE_PDF,
-    function(PdfSaveEvent $event) {
+    function(PdfEvent $event) {
         // @var Pdf $pdf
         $pdf = $event->pdf;
         // @var bool $isNew
@@ -1722,7 +1716,9 @@ Event::on(
 );
 ```
 
-### `beforeSaveProductType`
+### Product Types
+
+#### `beforeSaveProductType`
 
 The event that is triggered before a product type is saved.
 
@@ -1745,7 +1741,7 @@ Event::on(
 );
 ```
 
-### `afterSaveProductType`
+#### `afterSaveProductType`
 
 The event that is triggered after a product type has been saved.
 
@@ -1768,7 +1764,9 @@ Event::on(
 );
 ```
 
-### `registerPurchasableElementTypes`
+### Purchasables
+
+#### `registerPurchasableElementTypes`
 
 The event that is triggered for registration of additional purchasables.
 
@@ -1788,27 +1786,7 @@ Event::on(
 );
 ```
 
-### `registerAvailableShippingMethods`
-
-The event that is triggered for registration of additional shipping methods.
-
-This example adds an instance of `MyShippingMethod` to the event object’s `shippingMethods` array:
-
-```php
-use craft\commerce\events\RegisterAvailableShippingMethodsEvent;
-use craft\commerce\services\ShippingMethods;
-use yii\base\Event;
-
-Event::on(
-    ShippingMethods::class,
-    ShippingMethods::EVENT_REGISTER_AVAILABLE_SHIPPING_METHODS,
-    function(RegisterAvailableShippingMethodsEvent $event) {
-        $event->shippingMethods[] = MyShippingMethod::class;
-    }
-);
-```
-
-### `purchasableAvailable`
+#### `purchasableAvailable`
 
 The event that’s triggered when determining whether a purchasable should be available for a given current user and cart.
 
@@ -1871,6 +1849,28 @@ Event::on(
             // Prevent users in group ID 1 from being able to ship this purchasable
             $event->isShippable = $event->is && !$user->isInGroup(1);
         }
+    }
+);
+```
+
+### Shipping
+
+#### `registerAvailableShippingMethods`
+
+The event that is triggered for registration of additional shipping methods.
+
+This example adds an instance of `MyShippingMethod` to the event object’s `shippingMethods` array:
+
+```php
+use craft\commerce\events\RegisterAvailableShippingMethodsEvent;
+use craft\commerce\services\ShippingMethods;
+use yii\base\Event;
+
+Event::on(
+    ShippingMethods::class,
+    ShippingMethods::EVENT_REGISTER_AVAILABLE_SHIPPING_METHODS,
+    function(RegisterAvailableShippingMethodsEvent $event) {
+        $event->shippingMethods[] = MyShippingMethod::class;
     }
 );
 ```

--- a/docs/commerce/4.x/extend/events.md
+++ b/docs/commerce/4.x/extend/events.md
@@ -1814,7 +1814,7 @@ If the purchasable becomes unavailable after being added to the cart, an [order 
 
 The event that is triggered retrieving the list of purchasables for the add a line item feature on the order edit page.
 
-This example adds a condition to the query to only return purchasables with a SKU that contains `foo`
+This example adds a condition to the query to only return purchasables with a SKU that contains `foo`:
 
 ```php
 use craft\commerce\controllers\OrdersController;

--- a/docs/commerce/4.x/orders-carts.md
+++ b/docs/commerce/4.x/orders-carts.md
@@ -26,7 +26,7 @@ Let’s go over a few common actions you may want to perform on a cart:
 - [Working with Line Items](#working-with-line-items)
 - [Loading a Cart](#loading-a-cart)
 - [Using Custom Fields](#storing-data-in-custom-fields)
-- [Forgetting a Cart](#forgetting-a-cart)
+- [Forgetting](#forget-a-cart) and [loading](#load-a-cart) carts
 
 More topics are covered in separate pages:
 
@@ -271,9 +271,13 @@ Each line item includes several totals:
 - **lineItem.adjustmentsTotal** is the sum of each of the line item’s adjustment `amount` values.
 - **lineItem.total** is the sum of the line item’s `subtotal` and `adjustmentsTotal`.
 
-### Loading a Cart
+### Loading and Forgetting Carts
 
-Commerce provides a `commerce/cart/load-cart` endpoint for loading an existing cart into a cookie for the current customer.
+“Loading” and “forgetting” are a pair of actions that affect what cart is associated with the customer’s session.
+
+#### Load a Cart
+
+Commerce provides a [`commerce/cart/load-cart`](dev/controller-actions.md#get-post-cart-load-cart) endpoint for loading an existing cart into a cookie for the current customer.
 
 You can have the user interact with the endpoint by either [navigating to a URL](#loading-a-cart-with-a-url) or by [submitting a form](#loading-a-cart-with-a-form). Either way, the cart number is required.
 
@@ -283,7 +287,7 @@ Each method will store any errors in the session’s error flash data (`craft.ap
 If the desired cart belongs to a user, that user must be logged in to load it into a browser cookie.
 :::
 
-The [`loadCartRedirectUrl`](config-settings.md#loadcartredirecturl) setting determines where the customer will be sent by default after the cart’s loaded.
+The [`loadCartRedirectUrl`](config-settings.md#loadcartredirecturl) setting determines where the customer will be sent by default after the cart has been loaded.
 
 #### Loading a Cart with a URL
 
@@ -338,13 +342,13 @@ This is a simplified version of [`shop/cart/load.twig`](https://github.com/craft
 
 #### Restoring Previous Cart Contents
 
-If the customer’s a registered user they may want to continue shopping from another browser or computer. If that customer has an empty cart—as they would by default—and they log into the site, any previous cart will automatically be loaded.
+If the customer is a registered user, they may want to continue shopping from another browser or computer. If they have an empty cart on the second device (as they would by default) and they log in, their most recently-created cart will automatically be loaded.
 
 ::: tip
-If a customer is a guest with a cart and they create an account, that cart will be maintained after logging in.
+When a guest with an active cart creates an account, that cart will be remain active after logging in.
 :::
 
-You can allow a customer to see previously-loaded carts:
+You can allow a logged-in customer to see their previously used carts:
 
 ::: code
 ```twig
@@ -388,7 +392,7 @@ if ($currentUser) {
 ```
 :::
 
-You could then loop over the line items in those older carts and allow the customer to add them to the current order:
+You could then loop over the line items in those older carts and allow the customer to add them to their current cart:
 
 ```twig
 <h2>Previous Cart Items</h2>
@@ -401,15 +405,40 @@ You could then loop over the line items in those older carts and allow the custo
     {% for lineItem in oldCart.lineItems %}
       {{ lineItem.description }}
       <label>
-        {{ input('checkbox', 'purchasables[][id]', lineItem.getPurchasable().id) }}
+        {{ input('checkbox', 'purchasables[][id]', lineItem.purchasableId) }}
         Add to cart
       </label>
     {% endfor %}
   {% endfor %}
 
-  <button>Update Cart</button>
+  <button>Add Items</button>
 </form>
 ```
+
+### Forgetting a Cart <Since ver="4.3.0" product="craftcms/commerce" feature="The ability to forget a cart" />
+
+A logged-in customer’s cart is stored in a cookie that persists across sessions, so they can close their browser and return to the store without losing their cart. If the customer logs out, their cart will automatically be forgotten.
+
+Removing all the items from a cart doesn’t mean that the cart is forgotten, though—sometimes, fully detaching a cart from the session is preferable to emptying it. To remove a cart from the customer’s session (without logging out or clearing the items), make a `POST` request to the [`cart/forget-cart` action](dev/controller-actions.md#post-cart-forget-cart). A cart number is _not_ required—Commerce can only detach the customer’s current cart.
+
+The next time the customer makes a request to the [`update-cart` action](dev/controller-actions.md#post-cart-update-cart), they will be given a new cart
+
+::: tip
+In previous versions, you can call the `forgetCart()` method manually to remove the current cart cookie. The cart itself will not be deleted—just disassociated with the customer’s session until it’s loaded again by some other means.
+
+::: code
+```twig
+{# Forget the cart in the current session. #}
+{{ craft.commerce.carts.forgetCart() }}
+```
+```php
+use craft\commerce\Plugin as Commerce;
+
+// Forget the cart in the current session.
+Commerce::getInstance()->getCarts()->forgetCart();
+```
+:::
+:::
 
 ### Storing Data in Custom Fields
 
@@ -437,27 +466,6 @@ You can update custom fields on a cart by posting data to the [`commerce/cart/up
   <button>Update Cart</button>
 </form>
 ```
-
-### Forgetting a Cart
-
-A logged-in customer’s cart is stored in a cookie that persists across sessions, so they can close their browser and return to the store without losing their cart.
-
-If the customer logs out, their cart will automatically be forgotten.
-
-You can call the `forgetCart()` method manually to remove the current cart cookie. The cart itself will not be deleted, but disassociated with any sessions until it’s loaded again.
-
-::: code
-```twig
-{# Forget the cart in the current session. #}
-{{ craft.commerce.carts.forgetCart() }}
-```
-```php
-use craft\commerce\Plugin as Commerce;
-
-// Forget the cart in the current session.
-Commerce::getInstance()->getCarts()->forgetCart();
-```
-:::
 
 ## Orders
 

--- a/docs/commerce/4.x/orders-carts.md
+++ b/docs/commerce/4.x/orders-carts.md
@@ -7,6 +7,8 @@ Variants are added to a _cart_ that can be completed to become an _order_. Carts
 
 When we use the terms “cart” and “order”, we’re always referring to an [Order](commerce4:craft\commerce\elements\Order) element; a cart is simply an order that hasn’t been completed—meaning its `isCompleted` property is `false` and its `dateCompleted` is `null`.
 
+Typically, a cart is completed in response to a customer [making a payment](./making-payments.md)—or by satisfying other requirements you’ve defined through [configuration](./config-settings.md) or an [extension](./extend/README.md).
+
 ## Carts
 
 As a customer or store manager is building a cart, the goal is to maintain an up-to-date list of items with their relevant costs, discounts, and promotions. For this reason, the cart will be recalculated each time a change is made.

--- a/docs/commerce/4.x/orders-carts.md
+++ b/docs/commerce/4.x/orders-carts.md
@@ -415,7 +415,7 @@ You could then loop over the line items in those older carts and allow the custo
 </form>
 ```
 
-### Forgetting a Cart <Since ver="4.3.0" product="craftcms/commerce" feature="The ability to forget a cart" />
+### Forgetting a Cart <Since ver="4.3.0" product="Commerce" repo="craftcms/commerce" feature="The ability to forget a cart" />
 
 A logged-in customer’s cart is stored in a cookie that persists across sessions, so they can close their browser and return to the store without losing their cart. If the customer logs out, their cart will automatically be forgotten.
 

--- a/docs/commerce/4.x/sales.md
+++ b/docs/commerce/4.x/sales.md
@@ -8,6 +8,12 @@ An item in the store would typically be listed by its sale price. If no sales ap
 
 Sales are ordered in the control panel, and the system always runs through each sale in order when determining the `salePrice` of the purchasable.
 
+## Matching Items
+
+Controls that determine what purchasables match a sale are identical to those for [discounts](discounts.md).
+
+<See path="discounts.md" hash="discount-matching-items" label="Discount Matching Rules" description="Learn about matching behaviors shared between sales and discounts." />
+
 ## Conditions
 
 When creating a sale, you can set a number of conditions to be evaluated when determining if the sale should be applied to the purchasable. All conditions must match to have the sale applied. Leaving a condition empty ignores that condition.
@@ -27,30 +33,6 @@ When the sale stops being applied to matching products.
 ### User Group
 
 Whether the cart’s customer belongs to one of the matching user groups.
-
-### Variant
-
-Whether the purchasable being matched is one of the selected variants.
-
-### Category
-
-Whether the purchasable being matched is related to the selected category.
-
-For example, you might have a category of products in the “Womens Sport” department category, and this allows you to put all products in that category on sale.
-
-For variants, the category can be related to either the product or the variant to match this condition.
-
-Each custom purchasable can decide to determine how it considers the selected category.
-
-### Category Relationship Type
-
-This field specifies the type of relationship must exist between the purchasable and category in order for the condition to be met. There are three options available “Source”, “Target” and “Both”:
-
-- **Source**: the relational field exists on the product/purchasable.
-- **Target**: the category has a product/variant relational field.
-- **Both**: the relationship can be either **Source** or **Target**
-
-For more information on how this works, see [Relations Terminology](/4.x/relations.md#terminology).
 
 ### Other Purchasables
 


### PR DESCRIPTION
See the [4.3 changelog](https://github.com/craftcms/commerce/blob/4.3/CHANGELOG.md)!

- [x] `craft\commerce\controllers\OrdersController::EVENT_MODIFY_PURCHASABLES_QUERY`
- [x] Added `craft\commerce\services\Orders::afterSaveAddressHandler()` (Changing an address in a user’s address book copies those values to any carts that point to it via `sourceBillingAddressId` or `sourceShippingAddressId`)
- [x] The `commerce/cart/update-cart` action now accepts `firstName` and `lastName` in address params. (We can remove any language that discourages sending separate values.)
- [x] Added the `commerce/cart/forget-cart` action.
- [x] Guest customers registering during checkout now have their addresses saved to their account.
- [x] Discounts + Sales can now select entries in addition to categories (“Entrification”)
- [ ] New `ProductQuery` params for Shipping and Tax categories
- [x] Example templates no longer use HTMx or Tailwind color themes, no more CDN URLs
- [x] Deprecated: Payment sources should not be submitted at the same time as subscription creation.