### PR TITLE
Update element-types.md

### DIFF
--- a/docs/4.x/extend/element-types.md
+++ b/docs/4.x/extend/element-types.md
@@ -130,7 +130,7 @@ Note that we’ve also specified `id`, `dateCreated`, `dateUpdated`, and `uid` �
 Plugins should always keep their [install migration](./migrations.md#plugin-install-migrations) up to date. If this is your plugin’s first migration, it can live solely in `Install.php`; otherwise, equivalent code will also need to be added via a regular migration.
 :::
 
-Install your plugin (or run `php migrate/up`) to create the database table.
+Install your plugin (or run `php craft migrate/up --plugin=my-plugin`) to create the database table.
 
 ### Save Hooks
 


### PR DESCRIPTION
Corrected CLI migrate command

### Description
Under [migrations](https://craftcms.com/docs/4.x/extend/element-types.html#migrations) reader is told to use `php migrate/up` to apply database changes. The proper command appears to be `php craft migrate/up --plugin=my-plugin` if you are following the previous instructions.