### PR TITLE
Update element-types.md

### DIFF
--- a/docs/4.x/extend/element-types.md
+++ b/docs/4.x/extend/element-types.md
@@ -56,7 +56,7 @@ class Product extends Element
     }
 
     public int $price = 0;
-    public string $currency = '';
+    public ?string $currency = null;
 
     // ...
 }

--- a/docs/4.x/extend/element-types.md
+++ b/docs/4.x/extend/element-types.md
@@ -56,7 +56,7 @@ class Product extends Element
     }
 
     public int $price = 0;
-    public string $currency;
+    public string $currency = '';
 
     // ...
 }


### PR DESCRIPTION
$currency type needs an initial value

### Description
Under [Element Class](https://craftcms.com/docs/4.x/extend/element-types.html#element-class) using the given code example produces an error

`Typed property my\plugin\elements\Product::$currency must not be accessed before initialization`

This Stqackoverflow answer [Updating to Craft 4 breaks plugin settings: must not be accessed before initialization](https://craftcms.stackexchange.com/questions/40131/updating-to-craft-4-breaks-plugin-settings-must-not-be-accessed-before-initiali) states that Yii 2/Craft 4 uses typed variables must be intitalized.

