### PR TITLE
Update cp-section.md: $hasCpSection must be bool

### DIFF
--- a/docs/4.x/extend/cp-section.md
+++ b/docs/4.x/extend/cp-section.md
@@ -69,7 +69,7 @@ namespace mynamespace;
 
 class Plugin extends \craft\base\Plugin
 {
-    public $hasCpSection = true;
+    public bool $hasCpSection = true;
 
     // ...
 }


### PR DESCRIPTION
Minor fix to avoid a PHP compile error I got (`Type of Plugin::$hasCpSection must be bool (as in class craft\base\Plugin)`) when following this part of the documentation.

### Description

Adds `bool` to the respective line