### PR TITLE
Update all queries to use {{%plugin_products}} in element-types.md

### DIFF
--- a/docs/4.x/extend/element-types.md
+++ b/docs/4.x/extend/element-types.md
@@ -144,7 +144,7 @@ use craft\helpers\Db;
 public function afterSave(bool $isNew)
 {
     if (!$this->propagating) {
-        Db::upsert('{{%products}}', [
+        Db::upsert('{{%plugin_products}}', [
             'id' => $this->id,
         ], [
             'price' => $this->price,


### PR DESCRIPTION
I noticed that prior examples were using `{{%plugin_products}}`.

The `Db::upsert()` example was only using `{{%products}}`
