### PR TITLE
Backport composer project tags

### DIFF
--- a/docs/3.x/installation.md
+++ b/docs/3.x/installation.md
@@ -13,7 +13,7 @@ You should be running Composer 1.3.0 or later. You can find out your installed v
 To create a new Craft project, run this command (substituting `path/to/my-project` with the path where Composer should create the project):
 
 ```bash
-composer create-project craftcms/craft=^1 path/to/my/project
+composer create-project craftcms/craft=^3 path/to/my/project
 ```
 
 Composer will take a few minutes to load everything. Once it’s done you’ll see a success message:

--- a/docs/3.x/installation.md
+++ b/docs/3.x/installation.md
@@ -13,7 +13,7 @@ You should be running Composer 1.3.0 or later. You can find out your installed v
 To create a new Craft project, run this command (substituting `path/to/my-project` with the path where Composer should create the project):
 
 ```bash
-composer create-project craftcms/craft=^3 path/to/my/project
+composer create-project "craftcms/craft:^3" path/to/my/project
 ```
 
 Composer will take a few minutes to load everything. Once it’s done you’ll see a success message:

--- a/docs/4.x/installation.md
+++ b/docs/4.x/installation.md
@@ -36,7 +36,7 @@ While we [strongly recommend](#why-ddev) DDEV for new Craft projects, [alternate
 1. Scaffold the project from the official [starter project](https://github.com/craftcms/craft):
 
     ```bash
-    ddev composer create -y --no-scripts craftcms/craft^4
+    ddev composer create -y --no-scripts "craftcms/craft:^4"
     ```
 
 1. Run the Craft setup wizard, and accept all defaults (in `[square brackets]`):

--- a/docs/4.x/installation.md
+++ b/docs/4.x/installation.md
@@ -36,7 +36,7 @@ While we [strongly recommend](#why-ddev) DDEV for new Craft projects, [alternate
 1. Scaffold the project from the official [starter project](https://github.com/craftcms/craft):
 
     ```bash
-    ddev composer create -y --no-scripts craftcms/craft
+    ddev composer create -y --no-scripts craftcms/craft^4
     ```
 
 1. Run the Craft setup wizard, and accept all defaults (in `[square brackets]`):

--- a/docs/5.x/install.md
+++ b/docs/5.x/install.md
@@ -36,7 +36,7 @@ While we [strongly recommend](#why-ddev) DDEV for new Craft projects, [alternate
 1. Scaffold the project from the official [starter project](https://github.com/craftcms/craft):
 
     ```bash
-    ddev composer create -y --no-scripts craftcms/craft=5.0.x-dev
+    ddev composer create -y --no-scripts "craftcms/craft:5.x-dev"
     ```
 
     ::: tip


### PR DESCRIPTION
### Description
Starting with v5, we're going to sync major versions of `craftcms/craft` with `craftcms/cms`.

So it doesn't get confusing, I went back and tagged 3.0.0 and 4.0.0, so it is consistent.

Also:
- quotes vals because zsh doesn't like caret
- changes 5 to `5.x-dev`, since 5.x is going to be the branch