### PR TITLE
--create-docroot flag is no longer required

### DIFF
--- a/docs/5.x/install.md
+++ b/docs/5.x/install.md
@@ -30,7 +30,7 @@ While we [strongly recommend](#why-ddev) DDEV for new Craft projects, [alternate
 1. Create DDEV configuration files:
 
     ```bash
-    ddev config --project-type=craftcms --docroot=web --create-docroot --php-version=8.2
+    ddev config --project-type=craftcms --docroot=web --php-version=8.2
     ```
 
 1. Scaffold the project from the official [starter project](https://github.com/craftcms/craft):


### PR DESCRIPTION
DDEV configuration: --create-docroot has been deprecated, --create-docroot flag is no longer required

