### PR TITLE
Update widget-types.md

### DIFF
--- a/docs/4.x/extend/widget-types.md
+++ b/docs/4.x/extend/widget-types.md
@@ -72,7 +72,7 @@ Each widget is rendered inside a HTML element with an `id` attribute like `widge
     Craft.MyWidget = Garnish.Base.extend({
         $widget: null,
         init: function(id) {
-            this.$widget = document.getElementById('#widget' + id);
+            this.$widget = document.getElementById('widget' + id);
 
             // ...
         },

--- a/docs/5.x/extend/widget-types.md
+++ b/docs/5.x/extend/widget-types.md
@@ -72,7 +72,7 @@ Each widget is rendered inside a HTML element with an `id` attribute like `widge
     Craft.MyWidget = Garnish.Base.extend({
         $widget: null,
         init: function(id) {
-            this.$widget = document.getElementById('#widget' + id);
+            this.$widget = document.getElementById('widget' + id);
 
             // ...
         },


### PR DESCRIPTION
document.getElementById doesn't require a `#` in the selector
