### PR TITLE
GraphQL: queryable enabled schema [#620]

### DIFF
--- a/docs/5.x/development/graphql.md
+++ b/docs/5.x/development/graphql.md
@@ -175,7 +175,7 @@ Craft has two types of schemas:
 1. A single **Public Schema** that defines which content should be available publicly.
 2. Any number of private schemas you create, each having its own secret **Access Token**.
 
-Any GraphQL API request without a token will use the Public Schema. Craft with otherwise use a valid token to determine the relevant schema.
+Any GraphQL API request without a token will use the Public Schema. Craft will otherwise use a valid token to determine the relevant schema.
 
 You can manage your schemas in the control panel at **GraphQL** → **Schemas**. In addition to defining the scope of each schema, you can also give them expiration dates, regenerate their tokens, and disable them.
 

--- a/docs/5.x/development/graphql.md
+++ b/docs/5.x/development/graphql.md
@@ -125,7 +125,13 @@ mutation saveEntry($title: String, $slug: String) {
 
 ## Setting Up Your API Endpoint
 
-By default, none of your content is available outside of Craft via GraphQL. In order to send GraphQL queries to Craft, we need to establish an endpoint for receiving them and an appropriate set of permissions with a token.
+By default, none of your content is available outside of Craft via GraphQL. In order to send GraphQL queries to Craft, we need to enable a schema, and establish an endpoint for receiving queries and an appropriate set of permissions with a token.
+
+### Enable a GraphQL Schema
+
+You’ll need a queryable, enabled GraphQL schema.
+
+In the control panel at **GraphQL** → **Schemas**, edit the Public Schema: check "Query for elements", enable the schema, and save.
 
 ### Create a GraphQL Route
 


### PR DESCRIPTION
### Description

Leads users to enable a schema and make it queryable before trying the `ping`.

Not sure I've written "queriable"/"queryable" before. I see both are acceptable. As you can see in the 620 activity feed, I changed preference. Lmk if you'd like

```diff
- queryable
+ queriable
```

Also fixed a nearby typo.

### Related issues

- Fixes #620