### PR TITLE
Correct API link from v3 to v5

### DIFF
--- a/docs/5.x/extend/migrations.md
+++ b/docs/5.x/extend/migrations.md
@@ -46,7 +46,7 @@ Migration classes contain methods: [safeUp()](<yii2:yii\db\Migration::safeUp()>)
 You can usually ignore the `safeDown()` method, as Craft doesn’t have a way to revert migrations from the control panel.
 :::
 
-You have full access to [Craft’s API](https://docs.craftcms.com/api/v3/) from your `safeUp()` method, but plugin migrations should try to avoid calling the plugin’s own API here. As your plugin’s database schema changes over time, so will your APIs assumptions about the schema. If an old migration calls a service method that relies on database changes that haven’t been applied yet, it will result in a SQL error. So in general you should execute all SQL queries directly from your own migration class. It may feel like you’re duplicating code, but it will be more future-proof.
+You have full access to [Craft’s API](https://docs.craftcms.com/api/v5/) from your `safeUp()` method, but plugin migrations should try to avoid calling the plugin’s own API here. As your plugin’s database schema changes over time, so will your APIs assumptions about the schema. If an old migration calls a service method that relies on database changes that haven’t been applied yet, it will result in a SQL error. So in general you should execute all SQL queries directly from your own migration class. It may feel like you’re duplicating code, but it will be more future-proof.
 
 ### Manipulating Database Data
 


### PR DESCRIPTION
### Description

The docs are pointing to the V3 API, this corrects it to point to V5.


### Related issues

