### PR TITLE
Fix link to changelog in updating-plugins.md

### DIFF
--- a/docs/5.x/extend/updating-plugins.md
+++ b/docs/5.x/extend/updating-plugins.md
@@ -11,7 +11,7 @@ sidebarDepth: 2
 
 Craft 5 brings some of the most significant author- and developer-experience improvements _ever_—and in a way that is minimally disruptive to plugins.
 
-The [changelog](https://github.com/craftcms/cms/blob/5.0/CHANGELOG.md) is the most comprehensive and up-to-date list of added, changed, deprecated, and removed APIs. This guide focuses on high-level changes, organized by the features they impact.
+The [changelog](https://github.com/craftcms/cms/blob/5.x/CHANGELOG.md) is the most comprehensive and up-to-date list of added, changed, deprecated, and removed APIs. This guide focuses on high-level changes, organized by the features they impact.
 
 ::: tip
 Report issues with the upgrade guide in our [`craftcms/docs` repository](https://github.com/craftcms/docs/issues/new), and issues with the upgrade itself in the [`craftcms/cms` repository](https://github.com/craftcms/cms/issues/new?labels=bug%2Ccraft5&projects=&template=BUG-REPORT-V5.yml&title=%5B5.x%5D%3A+).


### PR DESCRIPTION
### Description

Looks like branch for Craft 5 has changed from `5.0` to `5.x` so the URL 404s now

### Related issues

