### PR TITLE
Fix typo with CRAFT_SECRETS_PATH constant example

### DIFF
--- a/docs/5.x/reference/config/bootstrap.md
+++ b/docs/5.x/reference/config/bootstrap.md
@@ -117,7 +117,7 @@ The path to a [secrets](../../configure.md#secrets) file, whose values are _not_
 
 ```php
 // Check the `secrets.php` file next to this script for sensitive values:
-define('CRAFT_SITE', dirname(__DIR__) . 'secrets.php');
+define('CRAFT_SECRETS_PATH', dirname(__DIR__) . 'secrets.php');
 ```
 
 ## `CRAFT_SITE`


### PR DESCRIPTION
### Description

The CRAFT_SITE constant has been duplicated for the CRAFT_SECRETS_PATH example.

### Related issues

