### PR TITLE
Add `async` option to `csrfInput()`

### DIFF
--- a/docs/5.x/reference/twig/functions.md
+++ b/docs/5.x/reference/twig/functions.md
@@ -337,7 +337,8 @@ You can optionally set additional attributes on the tag by passing an `options` 
 
 ```twig
 {{ csrfInput({
-  id: 'csrf-input'
+  id: 'csrf-input',
+  async: true,
 }) }}
 ```
 


### PR DESCRIPTION
This PR adds the `async` option to the `csrfInput()` function (added in [5.1.0](https://github.com/craftcms/cms/blob/5.x/CHANGELOG.md#510---2024-04-30)) to demonstrate this it can be used here to override the [`asyncCsrfInputs`](https://craftcms.com/docs/5.x/reference/config/general.html#asynccsrfinputs) config setting. 

I also PR’d a note to the config setting in https://github.com/craftcms/cms/pull/15411.