### PR TITLE
Drop most `@web` references from the Craft 4 and 5 docs

### DIFF
--- a/docs/4.x/assets.md
+++ b/docs/4.x/assets.md
@@ -45,7 +45,7 @@ Out of the box, the only type of filesystem Craft supports is a “Local” dire
 - **Base Path**: Set the filesystem’s root directory on the server. This must be within your web root in order for public URLs to work.
 
 ::: tip
-The **Base Path** can be set to an environment variable or begin with an alias, just like the **Base URL**
+The **Base Path** can be set to an environment variable or begin with an alias, just like the **Base URL**.
 :::
 
 Craft/PHP must be able to write to any directories you use for a local filesystem.

--- a/docs/4.x/assets.md
+++ b/docs/4.x/assets.md
@@ -45,7 +45,7 @@ Out of the box, the only type of filesystem Craft supports is a “Local” dire
 - **Base Path**: Set the filesystem’s root directory on the server. This must be within your web root in order for public URLs to work.
 
 ::: tip
-The **Base Path** can be set to an environment variable or begin with an alias, just like the **Base URL**. Declaring both a `@web` and `@webroot` alias can simplify the process of configuring local filesystems.
+The **Base Path** can be set to an environment variable or begin with an alias, just like the **Base URL**
 :::
 
 Craft/PHP must be able to write to any directories you use for a local filesystem.

--- a/docs/4.x/config/README.md
+++ b/docs/4.x/config/README.md
@@ -297,7 +297,7 @@ Some settings and functions in Craft support [Yii aliases](https://www.yiiframew
 Out of the box, Craft provides these aliases—but you can override them or provide new ones with the <config4:aliases> config setting:
 
 | Alias | Description | Based On
-| ----- | ----------- | --------
+| --- | --- | ---
 | `@app` | Path to Craft’s source code. | [CRAFT_VENDOR_PATH](#craftvendorpath)
 | `@config` | Path to your `config/` folder. | [CRAFT_BASE_PATH](#craftbasepath)
 | `@contentMigrations` | Path to your `migrations/` folder. | [CRAFT_BASE_PATH](#craftbasepath)
@@ -311,8 +311,8 @@ Out of the box, Craft provides these aliases—but you can override them or prov
 | `@tests` | Path to your `tests/` folder. | [CRAFT_TESTS_PATH](#crafttestspath)
 | `@translations` | Path to your `translations/` folder. | [CRAFT_TRANSLATIONS_PATH](#crafttranslationspath)
 | `@vendor` | Path to your `vendor/` folder. | [CRAFT_VENDOR_PATH](#craftvendorpath)
-| `@web` | URL to the folder that contains the `index.php` file that was loaded for the request | [CRAFT_WEB_URL](#craftweburl)
-| `@webroot` | Path to the folder that contains the `index.php` file that was loaded for the request | [CRAFT_WEB_ROOT](#craftwebroot)
+| `@web` | URL to the folder that contains the `index.php` file that was loaded for the request. | [CRAFT_WEB_URL](#craftweburl)
+| `@webroot` | Path to the folder that contains the `index.php` file that was loaded for the request. | [CRAFT_WEB_ROOT](#craftwebroot)
 
 Aliases can be set to plain strings, or to the content of an environment variable. Keep in mind that **aliases are resolved recursively**, so you can define one based on another (including those whose values came from the environment):
 

--- a/docs/4.x/config/README.md
+++ b/docs/4.x/config/README.md
@@ -314,10 +314,6 @@ Out of the box, Craft provides these aliases—but you can override them or prov
 | `@web` | URL to the folder that contains the `index.php` file that was loaded for the request | [CRAFT_WEB_URL](#craftweburl)
 | `@webroot` | Path to the folder that contains the `index.php` file that was loaded for the request | [CRAFT_WEB_ROOT](#craftwebroot)
 
-::: tip
-To prevent a variety of security issues, we recommend explicitly setting the `@web` alias with a fully-qualified URL, either via a configuration file (see below) or [environment variable](#env).
-:::
-
 Aliases can be set to plain strings, or to the content of an environment variable. Keep in mind that **aliases are resolved recursively**, so you can define one based on another (including those whose values came from the environment):
 
 ```php
@@ -325,17 +321,17 @@ use craft\helpers\App;
 
 return [
     'aliases' => [
-        '@web' => App::env('PRIMARY_SITE_URL'),
+        '@primaryUrl' => App::env('PRIMARY_SITE_URL'),
         '@shared' => App::env('SHARED_PATH'),
         '@uploads' => '@shared/web/uploads',
-        '@assets' => '@web/uploads',
+        '@assets' => '@primaryUrl/uploads',
     ],
 ];
 ```
 
 Assuming `PRIMARY_SITE_URL` is defined as `https://my-project.ddev.site` and `SHARED_PATH` is `/var/www/releases/123/shared`, these aliases would evaluate to:
 
-- `@web`: `https://my-project.ddev.site`
+- `@primaryUrl`: `https://my-project.ddev.site`
 - `@shared`: `/var/www/releases/123/shared`
 - `@uploads`: `/var/www/releases/123/shared/web/uploads`
 - `@assets`: `https://my-project.ddev.site/uploads`
@@ -389,7 +385,7 @@ Whenever you see this UI, you can provide a valid alias or environment variable 
 
 Focusing one of these fields will immediately suggest some values. Type `$` followed by an environment variable’s name or `@` followed by an alias to narrow the suggestions and find your placeholder.
 
-Aliases have the extra benefit of allowing extra path segments, so `@web/uploads` is a perfectly valid setting. If a combination of alias and path is used frequently, though, it might make sense to [define a specific `@uploads` alias](#aliases) and use that in the control panel, instead.
+Aliases have the extra benefit of allowing extra path segments, so `@primaryUrl/uploads` is a perfectly valid setting. If a combination of alias and path is used frequently, though, it might make sense to [define a specific `@uploads` alias](#aliases) and use that in the control panel, instead.
 
 ::: tip
 Plugins can add support for environment variables and aliases in their settings as well. See [Environmental Settings](../extend/environmental-settings.md) to learn how.
@@ -732,8 +728,8 @@ The path to the [vendor/](../directory-structure.md#vendor) folder. (It is assum
 
 ### `CRAFT_WEB_URL`
 
-Automatically sets the `@web` [alias](#aliases). Platforms (like [DDEV](../installation.md)) can set this to ensure Craft is pre-configured with the correct public URL.
+Automatically sets the `@web` [alias](#aliases).
 
 ### `CRAFT_WEB_ROOT`
 
-Automatically sets the `@webroot` [alias](#aliases), like [`CRAFT_WEB_URL`](#craft-web-url).
+Automatically sets the `@webroot` [alias](#aliases).

--- a/docs/4.x/sites.md
+++ b/docs/4.x/sites.md
@@ -99,11 +99,6 @@ If you have multiple sites using different root domains like `https://site-a.com
 If your primary site’s Base URL includes a subdirectory (i.e. `https://foo.dev/bar/`), you should set the [baseCpUrl](config4:baseCpUrl) config setting.
 :::
 
-::: warning
-Careful using the `@web` alias to define your sites’ Base URLs.  
-You should explicitly override the alias to avoid introducing a [cache poisoning](https://www.owasp.org/index.php/Cache_Poisoning) vulnerability, and to make sure Craft can reliably determine which site is being requested. See [Aliases](config/#aliases) for an example.
-:::
-
 ## Propagating Entries Across All Enabled Sites
 
 In the settings for each Channel Section is an option to propagate entries in that section across all sites. This is enabled by default, and is the only option for Single sections.

--- a/docs/5.x/configure.md
+++ b/docs/5.x/configure.md
@@ -326,24 +326,20 @@ use craft\helpers\App;
 
 return [
     'aliases' => [
-        '@web' => App::env('PRIMARY_SITE_URL'),
+        '@primaryUrl' => App::env('PRIMARY_SITE_URL'),
         '@shared' => App::env('SHARED_PATH'),
         '@uploads' => '@shared/web/uploads',
-        '@assets' => '@web/uploads',
+        '@assets' => '@primaryUrl/uploads',
     ],
 ];
 ```
 
 Assuming `PRIMARY_SITE_URL` is defined as `https://mydomain.com` and `SHARED_PATH` is `/var/www/releases/123/shared`, these aliases would evaluate to:
 
-- `@web`: `https://mydomain.com`
+- `@primaryUrl`: `https://mydomain.com`
 - `@shared`: `/var/www/releases/123/shared`
 - `@uploads`: `/var/www/releases/123/shared/web/uploads`
 - `@assets`: `https://mydomain.com/uploads`
-
-::: warning
-Setting `@web` can be problematic in multi-site installations that span multiple domains, or when accessing the control panel at a different domain from the front-end. In general, we recommend letting Craft determine this automatically, and using [environment variables](#control-panel-settings) to define the full base URI for each site.
-:::
 
 Recursive aliases are preferred to basic string interpolation, because they are evaluated at the time of _use_ rather than _definition_. Aliases are only resolved at the beginning of a string.
 
@@ -394,7 +390,7 @@ Whenever you see this UI, you can provide a valid alias or environment variable 
 
 Focusing one of these fields will immediately suggest some values. Type `$` followed by an environment variable’s name, or `@` followed by an alias to narrow the suggestions and find your placeholder.
 
-Aliases have the extra benefit of allowing extra path segments, so `@web/uploads` is a perfectly valid setting. If a combination of alias and path is used frequently, though, it might make sense to [define a specific alias](#aliases) (like `@uploads`) and use that in the control panel, instead. Environment variables _cannot_ be prepended to other values.
+Aliases have the extra benefit of allowing extra path segments, so `@primaryUrl/uploads` is a perfectly valid setting. If a combination of alias and path is used frequently, though, it might make sense to [define a specific alias](#aliases) (like `@uploads`) and use that in the control panel, instead. Environment variables _cannot_ be prepended to other values.
 
 ::: tip
 Plugins can add support for environment variables and aliases in their settings as well. See [Environmental Settings](extend/environmental-settings.md) to learn how.

--- a/docs/5.x/configure.md
+++ b/docs/5.x/configure.md
@@ -302,7 +302,7 @@ Some settings and functions in Craft support [Yii aliases](guide:concept-aliases
 Out of the box, Craft provides these aliases—but you can override them or provide new ones with the <config5:aliases> config setting:
 
 | Alias | Description | Based On
-| ----- | ----------- | --------
+| --- | --- | ---
 | `@app` | Path to Craft’s source code. | [CRAFT_VENDOR_PATH](reference/config/bootstrap.md#craft-vendor-path)
 | `@config` | Path to your `config/` folder. | [CRAFT_BASE_PATH](reference/config/bootstrap.md#craft-base-path)
 | `@contentMigrations` | Path to your `migrations/` folder. | [CRAFT_BASE_PATH](reference/config/bootstrap.md#craft-base-path)
@@ -316,8 +316,8 @@ Out of the box, Craft provides these aliases—but you can override them or prov
 | `@tests` | Path to your `tests/` folder. | [CRAFT_TESTS_PATH](reference/config/bootstrap.md#craft-tests-path)
 | `@translations` | Path to your `translations/` folder. | [CRAFT_TRANSLATIONS_PATH](reference/config/bootstrap.md#craft-translations-path)
 | `@vendor` | Path to your `vendor/` folder. | [CRAFT_VENDOR_PATH](reference/config/bootstrap.md#craft-vendor-path)
-| `@web` | URL to the folder that contains the `index.php` file that was loaded for the request | [CRAFT_WEB_URL](reference/config/bootstrap.md#craft-web-url)
-| `@webroot` | Path to the folder that contains the `index.php` file that was loaded for the request | [CRAFT_WEB_ROOT](reference/config/bootstrap.md#craft-web-root)
+| `@web` | URL to the folder that contains the `index.php` file that was loaded for the request. | [CRAFT_WEB_URL](reference/config/bootstrap.md#craft-web-url)
+| `@webroot` | Path to the folder that contains the `index.php` file that was loaded for the request. | [CRAFT_WEB_ROOT](reference/config/bootstrap.md#craft-web-root)
 
 Aliases can be set to plain strings, or to the content of an environment variable. Keep in mind that **aliases are resolved recursively**, so you can define one based on another (including those whose values came from the environment):
 

--- a/docs/5.x/reference/config/bootstrap.md
+++ b/docs/5.x/reference/config/bootstrap.md
@@ -155,8 +155,8 @@ The path to the [vendor/](../../system/directory-structure.md#vendor) folder. (I
 
 ## `CRAFT_WEB_URL`
 
-Automatically sets the `@web` [alias](../../configure.md#aliases). Platforms (like [DDEV](../../install.md)) can set this to ensure Craft is pre-configured with the correct public URL.
+Automatically sets the `@web` [alias](../../configure.md#aliases).
 
 ## `CRAFT_WEB_ROOT`
 
-Automatically sets the `@webroot` [alias](../../configure.md#aliases), like [`CRAFT_WEB_URL`](#craft-web-url).
+Automatically sets the `@webroot` [alias](../../configure.md#aliases).

--- a/docs/5.x/reference/element-types/assets.md
+++ b/docs/5.x/reference/element-types/assets.md
@@ -56,8 +56,6 @@ Out of the box, the only type of filesystem Craft supports is a “Local” dire
 
 ::: tip
 The **Base Path** can be set to an environment variable or begin with an alias, just like the **Base URL**.
-
-Avoid using the `@web` alias for Local filesystems’ **Base URL** unless you’ve set it to a fixed value across all sites. Otherwise, Craft may construct asset URLs that include that subpath and not properly map to the filesystem’s root.
 :::
 
 <a id="remote-volumes"></a>

--- a/docs/5.x/system/sites.md
+++ b/docs/5.x/system/sites.md
@@ -154,12 +154,6 @@ The first step is to create the new site in the **Settings** screen of your Craf
 7. Check the box for **This site has its own base URL** and provide a **Base URL**.
 8. Save the new site.
 
-::: warning
-Using `@web` in a site’s **Base URL** can cause unpredictable routing behavior and malformed URLs to non-default sites, or to the control panel—especially when those URLs don’t share a domain.
-
-Instead, set each site’s **Base URL** to a unique environment variable (like `BASE_URL_PRIMARY` and `BASE_URL_LABS`), or to an explicit value.
-:::
-
 ### Step 2 (Optional): Create Template Directories
 
 If you’d like to experiment with per-site [template overrides](#site-templates), create a new subdirectory within your `templates/` folder with the handle of your new site.


### PR DESCRIPTION
Drops most `@web` references from the Craft 4 and 5 docs.

Craft 4 and 5 no longer ever recommend using `@web`, and actively warn against it when already used (see https://github.com/craftcms/cms/pull/15347). At this point, mentioning it in the docs feels counter-productive.