### PR TITLE
Fix Craft version number in upgrade guide (4->5)

### DIFF
--- a/docs/5.x/upgrade.md
+++ b/docs/5.x/upgrade.md
@@ -179,7 +179,7 @@ Along with this update, you’ll need to integrate changes from our [starter pro
 
 ## Breaking Changes and Deprecations
 
-Features deprecated in Craft 4 may have been fully removed or replaced in Craft 4, and new deprecations have been flagged in Craft 5.
+Features deprecated in Craft 4 may have been fully removed or replaced in Craft 5, and new deprecations have been flagged in Craft 5.
 
 ::: warning
 This list focuses on high-traffic, user-facing features. Review the [complete changelog](repo:craftcms/cms/blob/5.x/CHANGELOG.md) for information about changes to specific APIs, including class deprecations, method signatures, and so on.


### PR DESCRIPTION
### Description
The guide contains a sentence `Features deprecated in Craft 4 may have been fully removed or replaced in Craft 4`. That last "Craft 4" number should of course be "Craft 5"

