### PR TITLE
Fix method signatures in Element::setEagerLoadedElements() example

### DIFF
--- a/docs/5.x/extend/element-types.md
+++ b/docs/5.x/extend/element-types.md
@@ -1151,14 +1151,14 @@ You may be able to create the source-target map without another database query, 
 If you need to override where eager-loaded elements are stored, add a `setEagerLoadedElements()` method to your element class as well:
 
 ```php
-public function setEagerLoadedElements(string $handle, array $elements): void
+public function setEagerLoadedElements(string $handle, array $elements, EagerLoadPlan $plan): void
 {
     // The handle can be anything, so long as it matches what is used in `eagerLoadingMap()`:
     if ($handle === 'author') {
         $author = $elements[0] ?? null;
         $this->setAuthor($author);
     } else {
-        parent::setEagerLoadedElements($handle, $elements);
+        parent::setEagerLoadedElements($handle, $elements, $plan);
     }
 }
 ```


### PR DESCRIPTION
### Description

In the custom Element Types documentation for Craft 5, I noticed (ok, PHPStorm _noticed for me_) that the method signature for the `setEagerLoadedElements()` example is missing the third `$plan` param that [Craft 5 requires](https://github.com/craftcms/cms/commit/6f1653f9df426354c847fbc7c2b8483e74dd70ba#diff-5fbe1c0558b45c94cc43b583d1b593886dff6716ead54fb8b0dc8ae177756acdR303). 

This change adds that param to the example so that lazy developers like me can go back to copy+pasting code from the docs with wild abandon.

