### PR TITLE
Craft 5 upgrade instruction tweaks

### DIFF
--- a/docs/5.x/upgrade.md
+++ b/docs/5.x/upgrade.md
@@ -52,7 +52,8 @@ ddev start
 1. Capture a fresh database backup from your live environment and import it.
 1. Make sure you don’t have any pending or active jobs in your queue.
 1. Run `php craft project-config/rebuild` and allow any new background tasks to complete.
-1. Capture a database backup of your _local_ environment, just in case things go sideways.
+1. Run `php craft utils/fix-field-layout-uids`.
+1. Deploy any project config changes to your live environment. (Be sure to run `php craft up` or `php craft pc/apply`.)
 1. Note your current **Temp Uploads Location** setting in **Settings** &rarr; **Assets** &rarr; **Settings**.
 1. MySQL users: Add your database’s _current_ character set and collation to `.env`. If you have always used Craft’s defaults, this will be:
 


### PR DESCRIPTION
- Adds a step to run `utils/fix-field-layout-uids` (since Craft 5 will make you go back to v4 and run it, if there are any duplicate UUIDs within field layout configs, so might as well do it up front just in case).
- Adds a step to deploy project config changes as a result of `project-config/rebuild` or `utils/fix-field-layout-uids` (see https://github.com/craftcms/cms/issues/16411#issuecomment-2595947332).
- Removes the step about making a local DB backup. Shouldn’t be necessary because the local backup is basically going to be the same as the production backup you already created (plus any automated project config changes).
