### PR TITLE
Header anchor visibility while focused

### DIFF
--- a/docs/.vuepress/theme/styles/typography.pcss
+++ b/docs/.vuepress/theme/styles/typography.pcss
@@ -233,11 +233,14 @@
     @apply text-sm float-left opacity-0;
     font-size: 0.85em;
     margin-left: -0.87em;
-    padding-right: 0.23em;
     margin-top: 0.125em;
 
     &:hover {
       @apply no-underline;
+    }
+
+    &:focus {
+      @apply opacity-100;
     }
   }
 


### PR DESCRIPTION
Makes header anchor visible on focus, removes right padding for nicer focus style.