### PR TITLE
`create-project` is now `create`

### DIFF
--- a/docs/5.x/install.md
+++ b/docs/5.x/install.md
@@ -38,7 +38,7 @@ While we [strongly recommend](#why-ddev) DDEV for new Craft projects, [alternate
 1. Scaffold the project from the official [starter project](https://github.com/craftcms/craft):
 
     ```bash
-    ddev composer create-project "craftcms/craft"
+    ddev composer create "craftcms/craft"
     ```
 
     The setup wizard will start automatically! Accept all defaults (in `[square brackets]`), and note your chosen username and password.


### PR DESCRIPTION
### Description
I don't know a ton about this but I was following these instructions today and the console told me `create-project` is dead. 

<img width="784" height="299" alt="image" src="https://github.com/user-attachments/assets/0bd4b961-e7c0-48a4-8e2d-c8f49d77c686" />



### Related issues

