### PR TITLE
Adjust link colors slightly and make sure underlines get applied to l…

### DIFF
--- a/docs/.vuepress/theme/styles/typography.pcss
+++ b/docs/.vuepress/theme/styles/typography.pcss
@@ -103,6 +103,7 @@
 
   p:not(.theme-default-content-override) a,
   li:not(.theme-default-content-override) a,
+  table:not(.theme-default-content-override) a,
   dl a {
     @apply underline;
     text-decoration-color: var(--link-underline-color);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,7 @@ module.exports = {
         softer: "#fafbfe",
         blue: {
           "lighter": "#86A7F9",
-          "default": "#2E68F5",
+          "default": "#2963F5",
           "darker": "#1554F4",
         },
         red: "#da5a47",


### PR DESCRIPTION
…inks inside of tables

### Description
Minor style improvements:

- Typography: Added underlines to links in table elements to fix color only violation
- Colors: Adjusted the default blue color from #2E68F5 to #2963F5 for improved contrast/accessibility against light gray background

### Related issues
N/A
