### PR TITLE
Put overflowing containers in the focus order so they are keyboard-accessible

### DIFF
--- a/docs/.vuepress/theme/layouts/Layout.vue
+++ b/docs/.vuepress/theme/layouts/Layout.vue
@@ -282,7 +282,17 @@ export default {
 
     this.$router.afterEach(() => {
       this.isSidebarOpen = false;
+      this.$nextTick(() => {
+        this.makeScrollingCodeBlocksFocusable();
+      });
+      
     });
+
+    this.$nextTick(() => {
+      this.makeScrollingCodeBlocksFocusable();
+    });
+
+    this.makeScrollingCodeBlocksFocusable();
 
     // temporary means of scrolling to URL hash on load
     // https://github.com/vuejs/vuepress/issues/2428
@@ -364,6 +374,14 @@ export default {
   },
 
   methods: {
+    makeScrollingCodeBlocksFocusable() {
+      document.querySelectorAll('pre').forEach(el => {
+        if (el.scrollWidth > el.clientWidth) {
+          el.setAttribute('tabindex', '0');
+        }
+      });
+    },
+
     toggleSidebar(to) {
       this.temporarilyAnimateBody();
       this.isSidebarOpen = typeof to === "boolean" ? to : !this.isSidebarOpen;

--- a/docs/.vuepress/theme/layouts/Layout.vue
+++ b/docs/.vuepress/theme/layouts/Layout.vue
@@ -170,6 +170,7 @@ import {
   getPageWithRelativePath,
   fixDoubleSlashes,
   getSameContentForVersion,
+  makeOverflowingContainersFocusable,
 } from "../util";
 
 import { getStorage, setStorage, unsetStorage } from "../Storage";
@@ -187,7 +188,10 @@ export default {
 
   watch: {
     '$route.path'() {
-      this.$refs.backToTop.focus()
+      this.$refs.backToTop.focus();
+      this.$nextTick(function () {
+        makeOverflowingContainersFocusable();
+      });
     }
   },
 
@@ -282,17 +286,11 @@ export default {
 
     this.$router.afterEach(() => {
       this.isSidebarOpen = false;
-      this.$nextTick(() => {
-        this.makeScrollingCodeBlocksFocusable();
-      });
-      
     });
 
-    this.$nextTick(() => {
-      this.makeScrollingCodeBlocksFocusable();
+    this.$nextTick(function () {
+      makeOverflowingContainersFocusable();
     });
-
-    this.makeScrollingCodeBlocksFocusable();
 
     // temporary means of scrolling to URL hash on load
     // https://github.com/vuejs/vuepress/issues/2428
@@ -374,14 +372,6 @@ export default {
   },
 
   methods: {
-    makeScrollingCodeBlocksFocusable() {
-      document.querySelectorAll('pre').forEach(el => {
-        if (el.scrollWidth > el.clientWidth) {
-          el.setAttribute('tabindex', '0');
-        }
-      });
-    },
-
     toggleSidebar(to) {
       this.temporarilyAnimateBody();
       this.isSidebarOpen = typeof to === "boolean" ? to : !this.isSidebarOpen;

--- a/docs/.vuepress/theme/util/index.js
+++ b/docs/.vuepress/theme/util/index.js
@@ -624,6 +624,21 @@ function getAnchorHash(path) {
 }
 
 /**
+ * Adds tabindex="0" to all containers (e.g., <pre>, <div>, etc.) that have overflowing content,
+ * making them focusable for keyboard navigation accessibility.
+ *
+ * This utility is typically used to improve accessibility for code blocks or other scrollable regions,
+ * allowing users to focus and scroll them using the keyboard.
+ */
+export function makeOverflowingContainersFocusable() {
+  document.querySelectorAll('pre,.toggle-tip .wrapper,.viewport.limit-height').forEach(el => {
+    if (el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight) {
+      el.setAttribute('tabindex', '0');
+    }
+  });
+}
+
+/**
  * Returns doc set base paths combinations with their configs,
  * accounting for set base, version, and/or language.
  *


### PR DESCRIPTION
### Description
Looks for containers (specified classes/elements) that are scrolling and adds `tabindex="0"`

### Related issues

