### PR TITLE
Update text color for `.pre-heading-title` to ensure minimum contrast ratios are met

### DIFF
--- a/docs/.vuepress/theme/components/PreHeading.vue
+++ b/docs/.vuepress/theme/components/PreHeading.vue
@@ -11,8 +11,7 @@
 .theme-default-content {
   .pre-heading-title {
     @apply my-0 py-0 px-2 relative inline-block leading-normal uppercase rounded text-xs border tracking-wider;
-    color: #a0aec0;
-    border-color: var(--border-color);
+    border-color: currentColor;
   }
 }
 </style>

--- a/docs/.vuepress/theme/styles/color-mode.pcss
+++ b/docs/.vuepress/theme/styles/color-mode.pcss
@@ -163,10 +163,6 @@
     );
   }
 
-  .pre-heading-title {
-    @apply text-slate;
-  }
-
   .custom-block {
     div[class*="language-"] {
       background-color: rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
### Description
Can be reviewed for "Tutorial" heading above `h1` on [Getting Started Tutorial page](https://craftcms.com/docs/getting-started-tutorial/)

To verify, an automated accessibility test on this page should show 0 issues.

### Related issues

