### PR TITLE
Resolves all instances of missing alt text in Docs

### DIFF
--- a/docs/4.x/assets.md
+++ b/docs/4.x/assets.md
@@ -77,7 +77,7 @@ Asset field layouts can include the native **Alternative Text** <Poi label="1" t
   :poi="{
     altText: [90, 32.5],
   }">
-<img src="./images/assets-field-layout.png" />
+<img src="./images/assets-field-layout.png" alt="The field layout designer for an asset element. The content pane includes a Title field. The sidebar includes a native field called Alternative Text." />
 </BrowserShot>
 
 Craft 4 introduced the `alt` attribute to standardize the inclusion of assistive text on `img` elements that Craft generates—especially in the control panel. Alt text is also added when outputting an image with `asset.getImg()` in Twig. You can always render `img` elements yourself, using any [custom field](./fields.md) values, attributes, or combination thereof. 

--- a/docs/4.x/dev/twig-primer.md
+++ b/docs/4.x/dev/twig-primer.md
@@ -678,7 +678,7 @@ With [devMode](config4:devMode) on, Craft will output a stack trace for any erro
   url="https://my-project.ddev.site/example"
   :link="false"
   caption="Example Twig error reporting view.">
-<img src="../images/twig-errors.png" />
+<img src="../images/twig-errors.png" alt="An error reporting page showing there was a Twig Runtime Error because the variable 'var' does not exist." />
 </BrowserShot>
 
 ::: tip

--- a/docs/4.x/fields.md
+++ b/docs/4.x/fields.md
@@ -18,7 +18,7 @@ All fields share a few settings:
 - **Field Type** – What [type](#field-types) of field it is;
 
 <BrowserShot url="https://my-project.tld/admin/settings/fields/new" :link="false" :max-height="500">
-<img src="./images/fields-field-settings.png">
+<img src="./images/fields-field-settings.png" alt="The 'Create a new field' page. In addition to the settings listed above, the field also includes settings for UI Mode, Placeholder text, maximum characters/bytes, and more." >
 </BrowserShot>
 
 ::: tip

--- a/docs/5.x/development/twig.md
+++ b/docs/5.x/development/twig.md
@@ -702,7 +702,7 @@ With [devMode](config5:devMode) on, Craft will output a stack trace for any erro
   url="https://my-project.ddev.site/example"
   :link="false"
   caption="Example Twig error reporting view.">
-<img src="../images/twig-errors.png" />
+<img src="../images/twig-errors.png" alt="An error reporting page showing there was a Twig Runtime Error because the variable 'var' does not exist." />
 </BrowserShot>
 
 ::: tip

--- a/docs/5.x/reference/element-types/assets.md
+++ b/docs/5.x/reference/element-types/assets.md
@@ -90,7 +90,7 @@ Asset field layouts can include the native **Alternative Text** <Poi label="1" t
   :poi="{
     altText: [28, 36.5],
   }">
-<img src="../../images/assets-field-layout.png" />
+<img src="../../images/assets-field-layout.png" alt="The field layout designer for an asset element. The content pane includes a Title field and an Alternative Text field."/>
 </BrowserShot>
 
 A native `alt` attribute is provided to standardize the inclusion of assistive text on `img` elements that Craft generates—especially in the control panel. Alt text is also added when outputting an image with `asset.getImg()` in Twig. You can always render `img` elements yourself, using any [custom field](../../system/fields.md) values, attributes, or combination thereof. 


### PR DESCRIPTION
### Description
Adds alt text to all images with missing alt text found via automated scan.

### Related issues
N/A
