### PR TITLE
Add 'k' as a hotkey for search box

### DIFF
--- a/docs/.vuepress/theme/components/SearchBox.vue
+++ b/docs/.vuepress/theme/components/SearchBox.vue
@@ -99,7 +99,7 @@ export default {
       focusIndex: 0,
       maxSuggestions: 10,
       suggestions: null,
-      hotkeys: ["/"]
+      hotkeys: ["/", "k"]
     };
   },
   computed: {


### PR DESCRIPTION
### Description

Added the "k" key as an additional hotkey to trigger the search box, alongside the existing "/" key, in `SearchBox.vue`

It’s much more of a muscle memory for me to use `⌘ + k` to search dev docs. This adds support for both shortcuts, similar to the docs here https://www.radix-ui.com/primitives/docs/overview/introduction