### PR TITLE
Add deprecation warning to Commerce 5.x subscriptions docs

### DIFF
--- a/docs/commerce/5.x/system/subscriptions.md
+++ b/docs/commerce/5.x/system/subscriptions.md
@@ -4,6 +4,10 @@ containsGeneratedContent: yes
 
 # Subscriptions
 
+::: warning
+Subscriptions are being removed in an upcoming release of Commerce. We recommend migrating to subscriptions managed by the [Stripe plugin](https://github.com/craftcms/stripe#migrating-from-craft-commerce).
+:::
+
 Commerce supports recurring revenue via _subscriptions_, a feature of [some gateways](#capabilities).
 
 Once you’ve added a payment gateway that supports subscriptions, navigate to <Journey path="Commerce, Subscription Plans" /> to set up one or more _plans_.


### PR DESCRIPTION
### Description

Adds a warning callout at the top of the Commerce 5.x subscriptions page noting that the feature is being removed in an upcoming release, with a link to the Stripe plugin's migration guide.

