### PR TITLE
Change custom status example

### DIFF
--- a/docs/5.x/extend/element-types.md
+++ b/docs/5.x/extend/element-types.md
@@ -843,8 +843,8 @@ By default, your elements will support two statuses: Enabled and Disabled. If yo
 public static function statuses(): array
 {
     return [
-        'foo' => ['label' => \Craft::t('plugin-handle', 'Foo'), 'color' => '27AE60'],
-        'bar' => ['label' => \Craft::t('plugin-handle', 'Bar'), 'color' => 'F2842D'],
+        'foo' => ['label' => \Craft::t('plugin-handle', 'Foo'), 'color' => Color::Indigo],
+        'bar' => ['label' => \Craft::t('plugin-handle', 'Bar'), 'color' => Color::Lime],
     ];
 }
 ```


### PR DESCRIPTION
Add Color class to custom status example, if you use plain string the status column will break on the panel.