### PR TITLE
Add redirect for legacy addresses page

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -23,7 +23,7 @@
 /docs/4.x/extend/volume-types.html /docs/4.x/extend/filesystem-types.html
 /docs/4.x/upgrading.html /docs/4.x/upgrade.html
 /docs/5.x/customers.html /docs/5.x/system/customers.html
-/docs/5.x/addresses.html /docs/5.x/reference/field-types/addresses.html
+/docs/5.x/addresses.html /docs/5.x/reference/element-types/addresses.html
 /docs/6.x/extend/introduction.html /docs/6.x/extend/index.html
 
 /docs/commerce/3.x/adding-to-and-updating-the-cart.html /docs/commerce/3.x/orders-carts.html#adding-items-to-a-cart

--- a/_redirects
+++ b/_redirects
@@ -23,6 +23,7 @@
 /docs/4.x/extend/volume-types.html /docs/4.x/extend/filesystem-types.html
 /docs/4.x/upgrading.html /docs/4.x/upgrade.html
 /docs/5.x/customers.html /docs/5.x/system/customers.html
+/docs/5.x/addresses.html /docs/5.x/reference/field-types/addresses.html
 /docs/6.x/extend/introduction.html /docs/6.x/extend/index.html
 
 /docs/commerce/3.x/adding-to-and-updating-the-cart.html /docs/commerce/3.x/orders-carts.html#adding-items-to-a-cart


### PR DESCRIPTION
## Summary
- add a Netlify redirect for the legacy Craft 5 addresses URL
- send `/docs/5.x/addresses.html` to the existing address field docs page

Fixes #772.

## Checks
- `curl -I -L https://craftcms.com/docs/5.x/addresses.html` currently returns 404
- `curl -I -L https://craftcms.com/docs/5.x/reference/field-types/addresses.html` returns 200
- verified branch diff only changes `_redirects`