### PR TITLE
Document k6 request signing

### DIFF
--- a/docs/cloud/request-signing.md
+++ b/docs/cloud/request-signing.md
@@ -42,11 +42,6 @@ const body = JSON.stringify({
   query: `{ entries(section: "blog") { title url } }`,
 });
 
-const headers = {
-  'Content-Type': 'application/json',
-  'Authorization': 'Bearer my-secret-gql-schema-token',
-};
-
 const created = new Date();
 
 const signer = {
@@ -61,7 +56,7 @@ const signer = {
 };
 
 const signatureHeaders = signatureHeadersSync(
-  { method, url, headers, body },
+  { method, url },
   {
     key: 'sig',
     signer,
@@ -76,7 +71,8 @@ const signatureHeaders = signatureHeadersSync(
 await fetch(url, {
   method,
   headers: {
-    ...headers,
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer my-secret-gql-schema-token',
     ...signatureHeaders,
   },
   body,

--- a/docs/cloud/request-signing.md
+++ b/docs/cloud/request-signing.md
@@ -116,10 +116,12 @@ export default function () {
   ].join(';');
 
   const signatureBase = [
-    `"@method": ${method}`,
-    `"@target-uri": ${url}`,
-    `"@signature-params": ${signatureParams}`,
-  ].join('\n');
+    ['@method', method],
+    ['@target-uri', url],
+    ['@signature-params', signatureParams],
+  ]
+    .map(([component, value]) => `"${component}": ${value}`)
+    .join('\n');
 
   const signature = crypto.hmac(
     'sha256',

--- a/docs/cloud/request-signing.md
+++ b/docs/cloud/request-signing.md
@@ -32,29 +32,29 @@ npm install http-message-sig
 Build and send a signed request like this:
 
 ```js
-import crypto from "node:crypto";
-import { signatureHeadersSync } from "http-message-sig";
+import crypto from 'node:crypto';
+import { signatureHeadersSync } from 'http-message-sig';
 
-const method = "POST";
-const url = "https://my-env.some-domain.com/api";
+const method = 'POST';
+const url = 'https://my-env.some-domain.com/api';
 
 const body = JSON.stringify({
   query: `{ entries(section: "blog") { title url } }`,
 });
 
 const headers = {
-  "Content-Type": "application/json",
-  Authorization: "Bearer my-secret-gql-schema-token",
+  'Content-Type': 'application/json',
+  'Authorization': 'Bearer my-secret-gql-schema-token',
 };
 
 const created = new Date();
 
 const signer = {
-  keyid: "hmac",
-  alg: "hmac-sha256",
+  keyid: 'hmac',
+  alg: 'hmac-sha256',
   signSync(data) {
     return crypto
-      .createHmac("sha256", process.env.CRAFT_CLOUD_SIGNING_KEY)
+      .createHmac('sha256', process.env.CRAFT_CLOUD_SIGNING_KEY)
       .update(data)
       .digest();
   },
@@ -63,9 +63,9 @@ const signer = {
 const signatureHeaders = signatureHeadersSync(
   { method, url, headers, body },
   {
-    key: "sig",
+    key: 'sig',
     signer,
-    components: ["@method", "@target-uri"],
+    components: ['@method', '@target-uri'],
     created,
 
     // Optional 60-second expiry. The maximum is five minutes.
@@ -93,11 +93,11 @@ The example above satisfies this by using the same `url` variable for the signed
 This example uses [Grafana Cloud k6](https://grafana.com/docs/k6/latest/examples/) with native dependencies:
 
 ```js
-import crypto from "k6/crypto";
-import http from "k6/http";
+import crypto from 'k6/crypto';
+import http from 'k6/http';
 
-const method = "POST";
-const url = "https://my-env.some-domain.com/api";
+const method = 'POST';
+const url = 'https://my-env.some-domain.com/api';
 
 const body = JSON.stringify({
   query: `{ entries(section: "blog") { title url } }`,
@@ -114,21 +114,21 @@ export default function () {
     `"@method": ${method}`,
     `"@target-uri": ${url}`,
     `"@signature-params": ${signatureParams}`,
-  ].join("\n");
+  ].join('\n');
 
   const signature = crypto.hmac(
-    "sha256",
+    'sha256',
     __ENV.CRAFT_CLOUD_SIGNING_KEY,
     signatureBase,
-    "base64"
+    'base64'
   );
 
   http.post(url, body, {
     headers: {
-      "Content-Type": "application/json",
-      Authorization: "Bearer my-secret-gql-schema-token",
-      "Signature-Input": `sig=${signatureParams}`,
-      Signature: `sig=:${signature}:`,
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer my-secret-gql-schema-token',
+      'Signature-Input': `sig=${signatureParams}`,
+      'Signature': `sig=:${signature}:`,
     },
   });
 }

--- a/docs/cloud/request-signing.md
+++ b/docs/cloud/request-signing.md
@@ -107,8 +107,13 @@ export default function () {
   const created = Math.floor(Date.now() / 1000);
   const expires = created + 60;
 
-  const signatureParams =
-    `("@method" "@target-uri");created=${created};expires=${expires};keyid="hmac";alg="hmac-sha256"`;
+  const signatureParams = [
+    '("@method" "@target-uri")',
+    `created=${created}`,
+    `expires=${expires}`,
+    'keyid="hmac"',
+    'alg="hmac-sha256"',
+  ].join(';');
 
   const signatureBase = [
     `"@method": ${method}`,

--- a/docs/cloud/request-signing.md
+++ b/docs/cloud/request-signing.md
@@ -32,72 +32,107 @@ npm install http-message-sig
 Build and send a signed request like this:
 
 ```js
-import crypto from 'node:crypto';
-import { signatureHeadersSync } from 'http-message-sig';
+import crypto from "node:crypto";
+import { signatureHeadersSync } from "http-message-sig";
 
-const method = 'POST';
-
-// These variables/secrets can be store in (and fetched from) the environment, instead:
-const url = 'https://my-env.some-domain.com/api';
-const schemaToken = 'WcVqivS64CCRQN9ohVcKk5FB6RIFTApd';
+const method = "POST";
+const url = "https://my-env.some-domain.com/api";
 
 const body = JSON.stringify({
-    query: `
-        {
-            entries(section: "blog") {
-                title
-                url
-            }
-        }
-    `,
+  query: `{ entries(section: "blog") { title url } }`,
 });
 
 const headers = {
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${schemaToken}`,
+  "Content-Type": "application/json",
+  Authorization: "Bearer my-secret-gql-schema-token",
 };
 
 const created = new Date();
 
 const signer = {
-    keyid: 'hmac',
-    alg: 'hmac-sha256',
-    signSync(data) {
-        return crypto
-            .createHmac('sha256', process.env.CRAFT_CLOUD_SIGNING_KEY)
-            .update(data)
-            .digest();
-    },
+  keyid: "hmac",
+  alg: "hmac-sha256",
+  signSync(data) {
+    return crypto
+      .createHmac("sha256", process.env.CRAFT_CLOUD_SIGNING_KEY)
+      .update(data)
+      .digest();
+  },
 };
 
 const signatureHeaders = signatureHeadersSync(
-    { method, url, headers, body },
-    {
-        key: 'sig',
-        signer,
-        components: ['@method', '@target-uri'],
-        created,
-        // This is optional (and cannot exceed five minutes, to validate at the edge):
-        expires: new Date(created.getTime() + 60_000),
-    },
+  { method, url, headers, body },
+  {
+    key: "sig",
+    signer,
+    components: ["@method", "@target-uri"],
+    created,
+
+    // Optional 60-second expiry. The maximum is five minutes.
+    expires: new Date(created.getTime() + 60 * 1000),
+  }
 );
 
-const response = await fetch(url, {
-    method,
-    headers: {
-        ...headers,
-        ...signatureHeaders,
-    },
-    body,
+await fetch(url, {
+  method,
+  headers: {
+    ...headers,
+    ...signatureHeaders,
+  },
+  body,
 });
-
-const result = await response.json();
 ```
 
 ::: tip
 Requests signed using the `@target-uri` [component](https://www.rfc-editor.org/rfc/rfc9421.html#name-derived-components) are only valid when sent to a URL that matches _exactly_, including the scheme, hostname, path, and query string.
 The example above satisfies this by using the same `url` variable for the signed request and the `fetch()` call.
 :::
+
+### From Grafana Cloud k6
+
+This example uses [Grafana Cloud k6](https://grafana.com/docs/k6/latest/examples/) with native dependencies:
+
+```js
+import crypto from "k6/crypto";
+import http from "k6/http";
+
+const method = "POST";
+const url = "https://my-env.some-domain.com/api";
+
+const body = JSON.stringify({
+  query: `{ entries(section: "blog") { title url } }`,
+});
+
+export default function () {
+  const created = Math.floor(Date.now() / 1000);
+  const expires = created + 60;
+
+  const signatureParams =
+    `("@method" "@target-uri");created=${created};expires=${expires};keyid="hmac";alg="hmac-sha256"`;
+
+  const signatureBase = [
+    `"@method": ${method}`,
+    `"@target-uri": ${url}`,
+    `"@signature-params": ${signatureParams}`,
+  ].join("\n");
+
+  const signature = crypto.hmac(
+    "sha256",
+    __ENV.CRAFT_CLOUD_SIGNING_KEY,
+    signatureBase,
+    "base64"
+  );
+
+  http.post(url, body, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer my-secret-gql-schema-token",
+      "Signature-Input": `sig=${signatureParams}`,
+      Signature: `sig=:${signature}:`,
+    },
+  });
+}
+```
 
 ### From Craft
 


### PR DESCRIPTION
Documents how to sign Craft Cloud requests from Grafana Cloud k6, and keeps the adjacent JavaScript examples focused on the same signing flow.