### PR TITLE
Fix command to create Craft CMS project

### DIFF
--- a/docs/getting-started-tutorial/install/README.md
+++ b/docs/getting-started-tutorial/install/README.md
@@ -27,7 +27,7 @@ Run the following commands to configure a new DDEV project in that folder:
 2. Scaffold the project from the official starter project:
 
     ```sh
-    ddev composer create -y "craftcms/craft"
+    ddev composer create-project "craftcms/craft"
     ```
 
     The setup wizard will start automatically. Answer the prompts, leaving `Site URL` set to the default value (`https://tutorial.ddev.site`)—unless you chose something other than `tutorial` when creating your [project folder](#project-folder).


### PR DESCRIPTION
I received the following error when using the current instructions:

```sh
% ddev composer create -y "craftcms/craft"

Command "create" is deprecated, please start using the identical "ddev composer create-project" instead
Executing Composer command: [composer create-project -y --no-plugins --no-scripts --no-install craftcms/craft /tmp/JDDmza]
 

                                   
  The "-y" option does not exist.  
                                   

create-project [-s|--stability STABILITY] [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--repository REPOSITORY] [--repository-url REPOSITORY-URL] [--add-repository] [--require REQUIRE] [--dev] [--no-dev] [--no-custom-installers] [--no-scripts] [--no-progress] [--no-secure-http] [--keep-vcs] [--remove-vcs] [--no-install] [--no-audit] [--audit-format AUDIT-FORMAT] [--no-security-blocking] [--no-blocking] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--ask] [--] [<package> [<directory> [<version>]]]

Failed to create project: exit status 1
```

So I used the suggested command and it worked:
```sh
ddev composer create-project "craftcms/craft"
```

