### PR TITLE
Add Craft Cloud Headless Apps guide

### DIFF
--- a/docs/.vuepress/sets/craft-cloud.js
+++ b/docs/.vuepress/sets/craft-cloud.js
@@ -52,6 +52,7 @@ module.exports = {
         children: [
           "compatibility",
           "static-caching",
+          "headless",
           "esi",
           "request-signing",
           "quotas",

--- a/docs/.vuepress/sets/craft-cloud.js
+++ b/docs/.vuepress/sets/craft-cloud.js
@@ -52,7 +52,7 @@ module.exports = {
         children: [
           "compatibility",
           "static-caching",
-          ["headless-apps", "Headless Apps"],
+          "headless-apps",
           "esi",
           "request-signing",
           "quotas",

--- a/docs/.vuepress/sets/craft-cloud.js
+++ b/docs/.vuepress/sets/craft-cloud.js
@@ -52,7 +52,7 @@ module.exports = {
         children: [
           "compatibility",
           "static-caching",
-          "headless",
+          ["headless-apps", "Headless Apps"],
           "esi",
           "request-signing",
           "quotas",

--- a/docs/cloud/headless-apps.md
+++ b/docs/cloud/headless-apps.md
@@ -162,7 +162,7 @@ Use narrow tags such as `craft:blog` or `craft:products`, and avoid bursts of
 app-wide invalidations. When revalidation throws, Next.js continues serving
 the last successful result and tries again on a later request.
 
-Vercel provides this stale-while-revalidate behavior through
+Vercel provides `stale-while-revalidate` behavior through
 [ISR](https://vercel.com/docs/incremental-static-regeneration). Netlify’s
 [current Next.js adapter](https://docs.netlify.com/build/frameworks/framework-setup-guides/nextjs/overview/)
 also supports the Full Route and Data caches, including tag- and path-based

--- a/docs/cloud/headless-apps.md
+++ b/docs/cloud/headless-apps.md
@@ -24,7 +24,7 @@ Two components are critical for a successful headless setup on Craft Cloud:
     with exponential backoff and jitter.
   - Only retry `POST` requests that contain read-only GraphQL queries—never
     mutations.
-  - Throw after retries are exhausted so stale-while-revalidate caching can
+  - Throw after retries are exhausted so `stale-while-revalidate` caching can
     preserve the last successful result.
 
 ## Automated Retries
@@ -209,7 +209,7 @@ export default defineEventHandler(async () => {
 });
 ```
 
-Apply stale-while-revalidate caching with a route rule, then call the route
+Apply `stale-while-revalidate` caching with a route rule, then call the route
 from your components with `useFetch('/api/blog')`:
 
 ```js
@@ -270,6 +270,6 @@ therefore leaves the current production app in place.
 
 For on-demand rendering, Astro 7 provides a
 [route cache API](https://docs.astro.build/en/guides/caching/) with
-stale-while-revalidate semantics. Its Netlify and Vercel CDN cache providers
+`stale-while-revalidate` semantics. Its Netlify and Vercel CDN cache providers
 are currently experimental, so use the static build approach unless runtime
 revalidation is required.

--- a/docs/cloud/headless-apps.md
+++ b/docs/cloud/headless-apps.md
@@ -116,7 +116,9 @@ framework-specific request options.
 [Next.js extends `fetch()`](https://nextjs.org/docs/app/api-reference/functions/fetch)
 with cache and revalidation options. This example uses
 [Ky](https://github.com/sindresorhus/ky), which passes those options through to
-the underlying Fetch implementation:
+the underlying Fetch implementation. Use Next.js 15.5.21 or later, or 16.2.11
+or later, to avoid a [cache-confusion vulnerability](https://github.com/vercel/next.js/security/advisories/GHSA-68g3-v927-f742)
+affecting requests with bodies:
 
 ```js
 import ky from 'ky';

--- a/docs/cloud/headless-apps.md
+++ b/docs/cloud/headless-apps.md
@@ -270,6 +270,4 @@ therefore leaves the current production app in place.
 
 For on-demand rendering, Astro 7 provides a
 [route cache API](https://docs.astro.build/en/guides/caching/) with
-`stale-while-revalidate` semantics. Its Netlify and Vercel CDN cache providers
-are currently experimental, so use the static build approach unless runtime
-revalidation is required.
+`stale-while-revalidate` semantics.

--- a/docs/cloud/headless-apps.md
+++ b/docs/cloud/headless-apps.md
@@ -5,7 +5,7 @@ description: Reliably connect a headless app to a Craft Cloud environment.
 # Headless Apps
 
 Craft Cloud uses advanced bot detection and makes a best effort to prioritize
-human traffic. This creates a challenge for headless apps: all content
+human traffic. This poses a challenge for headless apps: all content
 retrieval is automated and often arrives in concentrated bursts during static
 builds and background revalidation.
 

--- a/docs/cloud/headless-apps.md
+++ b/docs/cloud/headless-apps.md
@@ -158,9 +158,6 @@ if (result.errors?.length) {
 const data = result.data;
 ```
 
-The 30-second total timeout keeps all attempts and delays within the
-signature’s 60-second lifetime.
-
 Use narrow tags such as `craft:blog` or `craft:products`, and avoid bursts of
 app-wide invalidations. When revalidation throws, Next.js continues serving
 the last successful result and tries again on a later request.

--- a/docs/cloud/headless-apps.md
+++ b/docs/cloud/headless-apps.md
@@ -34,6 +34,7 @@ provide this retry policy. If you prefer not to add a dependency, use a small
 wrapper around the native Fetch API:
 
 ```js
+// Bound all attempts and delays.
 const TOTAL_TIMEOUT = 30_000;
 
 const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
@@ -41,6 +42,7 @@ const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
 function getRetryDelay(response, attempt) {
   const retryAfter = response.headers.get('Retry-After');
 
+  // Retry only responses that include Retry-After.
   if (!retryAfter) {
     return null;
   }
@@ -98,9 +100,6 @@ export async function fetchWithRetry(input, init = {}) {
   }
 }
 ```
-
-`fetchWithRetry()` retries responses with a `Retry-After` header that fit within
-a 30-second deadline.
 
 ## Request Signatures
 

--- a/docs/cloud/headless-apps.md
+++ b/docs/cloud/headless-apps.md
@@ -2,7 +2,7 @@
 description: Reliably connect a headless app to a Craft Cloud environment.
 ---
 
-# Headless
+# Headless Apps
 
 Craft Cloud uses advanced bot detection and makes a best effort to prioritize
 human traffic. This creates a challenge for headless apps: all content

--- a/docs/cloud/headless-apps.md
+++ b/docs/cloud/headless-apps.md
@@ -1,11 +1,11 @@
 ---
-description: Reliably connect a headless site to a Craft Cloud environment.
+description: Reliably connect a headless app to a Craft Cloud environment.
 ---
 
 # Headless
 
 Craft Cloud uses advanced bot detection and makes a best effort to prioritize
-human traffic. This creates a challenge for headless sites: all content
+human traffic. This creates a challenge for headless apps: all content
 retrieval is automated and often arrives in concentrated bursts during static
 builds and background revalidation.
 
@@ -164,7 +164,7 @@ The 30-second total timeout keeps all attempts and delays within the
 signature’s 60-second lifetime.
 
 Use narrow tags such as `craft:blog` or `craft:products`, and avoid bursts of
-site-wide invalidations. When revalidation throws, Next.js continues serving
+app-wide invalidations. When revalidation throws, Next.js continues serving
 the last successful result and tries again on a later request.
 
 Vercel provides this stale-while-revalidate behavior through
@@ -271,7 +271,7 @@ const data = result.data;
 
 Netlify uses [atomic deploys](https://docs.netlify.com/deploy/deploy-overview/),
 and Vercel promotes successful deployments to production. A failed build
-therefore leaves the current production site in place.
+therefore leaves the current production app in place.
 
 For on-demand rendering, Astro 7 provides a
 [route cache API](https://docs.astro.build/en/guides/caching/) with

--- a/docs/cloud/headless-apps.md
+++ b/docs/cloud/headless-apps.md
@@ -114,9 +114,7 @@ framework-specific request options.
 [Next.js extends `fetch()`](https://nextjs.org/docs/app/api-reference/functions/fetch)
 with cache and revalidation options. This example uses
 [Ky](https://github.com/sindresorhus/ky), which passes those options through to
-the underlying Fetch implementation. Use Next.js 15.5.21 or later, or 16.2.11
-or later, to avoid a [cache-confusion vulnerability](https://github.com/vercel/next.js/security/advisories/GHSA-68g3-v927-f742)
-affecting requests with bodies:
+the underlying Fetch implementation:
 
 ```js
 import ky from 'ky';

--- a/docs/cloud/headless-apps.md
+++ b/docs/cloud/headless-apps.md
@@ -34,27 +34,28 @@ provide this retry policy. If you prefer not to add a dependency, use a small
 wrapper around the native Fetch API:
 
 ```js
-const RETRYABLE_STATUSES = new Set([429, 503]);
 const TOTAL_TIMEOUT = 30_000;
 
 const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
 
 function getRetryDelay(response, attempt) {
-  const backoff = 1000 * 2 ** attempt * (0.5 + Math.random() / 2);
   const retryAfter = response.headers.get('Retry-After');
 
-  if (retryAfter) {
-    const seconds = Number(retryAfter);
+  if (!retryAfter) {
+    return null;
+  }
 
-    if (Number.isFinite(seconds)) {
-      return Math.max(backoff, seconds * 1000);
-    }
+  const backoff = 1000 * 2 ** attempt * (0.5 + Math.random() / 2);
+  const seconds = Number(retryAfter);
 
-    const date = Date.parse(retryAfter);
+  if (Number.isFinite(seconds)) {
+    return Math.max(backoff, seconds * 1000);
+  }
 
-    if (!Number.isNaN(date)) {
-      return Math.max(backoff, date - Date.now());
-    }
+  const date = Date.parse(retryAfter);
+
+  if (!Number.isNaN(date)) {
+    return Math.max(backoff, date - Date.now());
   }
 
   return backoff;
@@ -81,15 +82,13 @@ export async function fetchWithRetry(input, init = {}) {
     }
 
     const error = new Error(`Craft request failed: ${response.status}`);
-    const canRetry = RETRYABLE_STATUSES.has(response.status);
+    const delay = getRetryDelay(response, attempt);
 
     await response.body?.cancel();
 
-    if (!canRetry) {
+    if (delay === null) {
       throw error;
     }
-
-    const delay = getRetryDelay(response, attempt);
 
     if (Date.now() + delay >= deadline) {
       throw error;
@@ -100,9 +99,8 @@ export async function fetchWithRetry(input, init = {}) {
 }
 ```
 
-`fetchWithRetry()` retries only `429` and `503` responses that fit within a
-30-second deadline. Retry `POST` requests only when they contain read-only
-GraphQL queries.
+`fetchWithRetry()` retries responses with a `Retry-After` header that fit within
+a 30-second deadline.
 
 ## Request Signatures
 

--- a/docs/cloud/headless.md
+++ b/docs/cloud/headless.md
@@ -116,7 +116,7 @@ framework-specific request options.
 [Next.js extends `fetch()`](https://nextjs.org/docs/app/api-reference/functions/fetch)
 with cache and revalidation options. This example uses
 [Ky](https://github.com/sindresorhus/ky), which passes those options through to
-the underlying Fetch implementation. Install it with `npm install ky`:
+the underlying Fetch implementation:
 
 ```js
 import ky from 'ky';
@@ -127,13 +127,16 @@ const method = 'POST';
 const url = `${CRAFT_URL}/api`;
 const query = `{ entries(section: "blog") { title url } }`;
 const body = JSON.stringify({ query });
-const signatureHeaders = getSignatureHeaders(method, url);
+const headers = {
+  'Content-Type': 'application/json',
+  'Authorization': `Bearer ${CRAFT_GRAPHQL_TOKEN}`,
+};
+const signatureHeaders = getSignatureHeaders({ method, url, headers });
 
 const result = await ky.post(url, {
   body,
   headers: {
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${CRAFT_GRAPHQL_TOKEN}`,
+    ...headers,
     ...signatureHeaders,
   },
   retry: {
@@ -186,15 +189,18 @@ const method = 'POST';
 const url = `${CRAFT_URL}/api`;
 const query = `{ entries(section: "blog") { title url } }`;
 const body = JSON.stringify({ query });
+const headers = {
+  'Content-Type': 'application/json',
+  'Authorization': `Bearer ${CRAFT_GRAPHQL_TOKEN}`,
+};
 
 export default defineEventHandler(async () => {
-  const signatureHeaders = getSignatureHeaders(method, url);
+  const signatureHeaders = getSignatureHeaders({ method, url, headers });
   const response = await fetchWithRetry(url, {
     method,
     body,
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${CRAFT_GRAPHQL_TOKEN}`,
+      ...headers,
       ...signatureHeaders,
     },
   });
@@ -240,13 +246,16 @@ const method = 'POST';
 const url = `${CRAFT_URL}/api`;
 const query = `{ entries(section: "blog") { title url } }`;
 const body = JSON.stringify({ query });
-const signatureHeaders = getSignatureHeaders(method, url);
+const headers = {
+  'Content-Type': 'application/json',
+  'Authorization': `Bearer ${CRAFT_GRAPHQL_TOKEN}`,
+};
+const signatureHeaders = getSignatureHeaders({ method, url, headers });
 const response = await fetchWithRetry(url, {
   method,
   body,
   headers: {
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${CRAFT_GRAPHQL_TOKEN}`,
+    ...headers,
     ...signatureHeaders,
   },
 });

--- a/docs/cloud/headless.md
+++ b/docs/cloud/headless.md
@@ -114,8 +114,3 @@ revalidation as failed and preserve the last successful result.
 
 Adjust `next.revalidate` for your content. Use narrow tags such as `craft:blog`
 or `craft:products`, and avoid bursts of site-wide invalidations.
-
-## Diagnostics
-
-Log the response status, `x-gateway-http-signature`, and `Retry-After` when
-diagnosing failures. Never log signing keys or GraphQL tokens.

--- a/docs/cloud/headless.md
+++ b/docs/cloud/headless.md
@@ -4,35 +4,32 @@ description: Reliably connect a headless site to a Craft Cloud environment.
 
 # Headless
 
-A headless site typically runs its front end separately from Craft Cloud and
-retrieves content from Craft’s [GraphQL API](/5.x/development/graphql.md).
-Static builds and background revalidation can generate concentrated bursts of
-requests, so the front end must be prepared for temporary capacity limits.
+Craft Cloud uses advanced bot detection and makes a best effort to prioritize
+human traffic. This creates a challenge for headless sites: all content
+retrieval is automated and often arrives in concentrated bursts during static
+builds and background revalidation.
 
-Use this contract regardless of your front-end framework or hosting provider:
+Two components are critical for a successful headless setup on Craft Cloud:
 
-- [Sign requests](request-signing.md) from trusted server-side code. Never expose
-  the signing key to a browser or in a public environment variable.
-- Treat every non-2xx response as a failure. A verified signature bypasses the
-  untrusted-bot policy, not shared capacity limits, so signed requests may still
-  receive `429` or `503` responses.
-- For `429` and `503` responses, honor `Retry-After` and retry a limited number
-  of times with exponential backoff and jitter.
-- Retry `POST` requests only when they contain read-only GraphQL queries. Never
-  automatically retry mutations.
-- After retries are exhausted, throw an error rather than rendering or caching
-  an incomplete response. Pair this with stale-while-revalidate caching so the
-  front end can continue serving the last successful result.
+- **Signed requests:** [Sign requests](request-signing.md) from trusted
+  server-side code so they bypass the untrusted-bot policy. Signatures do not
+  bypass shared capacity limits, so signed requests can still receive `429` or
+  `503` responses. Never expose the signing key to a browser or in a public
+  environment variable.
+- **Automated retries:** Treat every non-2xx response as a failure. For `429` and
+  `503` responses, honor `Retry-After` and use bounded retries with exponential
+  backoff and jitter. Only retry `POST` requests that contain read-only GraphQL
+  queries—never mutations. Throw after retries are exhausted so
+  stale-while-revalidate caching can preserve the last successful result.
 
 ## Next.js on Vercel
 
-This example uses [Ky](https://github.com/sindresorhus/ky) because it treats
-non-2xx responses as errors and supports `Retry-After`, bounded retries,
-exponential backoff, jitter, and an overall timeout while preserving
+This example uses [Ky](https://github.com/sindresorhus/ky) to implement that
+retry policy while preserving
 [Next.js fetch options](https://nextjs.org/docs/app/api-reference/functions/fetch).
 
-Install Ky and the same signature library used in the general
-[Node.js signing example](request-signing.md#from-node-js):
+Install Ky and the signature library used in the general
+[Node.js example](request-signing.md#from-node-js):
 
 ```bash
 npm install ky http-message-sig
@@ -103,24 +100,15 @@ export async function queryCraft(query, variables = {}) {
 }
 ```
 
-The single retry keeps the request within the signature’s 60-second lifetime,
-and Ky throws after the retry or 30-second overall timeout. This allows
+The 30-second overall timeout keeps the retry within the signature’s 60-second
+lifetime. If the request still fails, Ky throws, allowing
 [Vercel ISR](https://vercel.com/docs/incremental-static-regeneration) to treat a
-background revalidation as failed and preserve the last successful result.
+revalidation as failed and preserve the last successful result.
 
-The `next` values are examples. Choose a revalidation interval appropriate for
-your content, and use narrow tags such as `craft:blog`, `craft:products`, or a
-specific section or entry. Prefer targeted revalidation over invalidating the
-entire site, and avoid triggering large bursts of invalidations when content is
-updated in bulk.
+Adjust `next.revalidate` for your content. Use narrow tags such as `craft:blog`
+or `craft:products`, and avoid bursts of site-wide invalidations.
 
 ## Diagnostics
 
-When a request fails, inspect its status and these response headers in your
-front-end deployment logs:
-
-- `x-gateway-http-signature` contains request-signature diagnostics; and
-- `Retry-After` tells the caller how long to wait before retrying a `429` or
-  `503` response.
-
-Do not log signing keys or GraphQL tokens while collecting diagnostics.
+Log the response status, `x-gateway-http-signature`, and `Retry-After` when
+diagnosing failures. Never log signing keys or GraphQL tokens.

--- a/docs/cloud/headless.md
+++ b/docs/cloud/headless.md
@@ -38,18 +38,18 @@ Install Ky and the same signature library used in the general
 npm install ky http-message-sig
 ```
 
-Configure `CRAFT_URL`, `CRAFT_GRAPHQL_TOKEN`, and
-`CRAFT_CLOUD_SIGNING_KEY` as server-side environment variables, then create a
-GraphQL helper:
+Create a GraphQL helper:
 
 ```js
 import crypto from 'node:crypto';
 import { signatureHeadersSync } from 'http-message-sig';
 import ky from 'ky';
 
+const { CRAFT_URL, CRAFT_GRAPHQL_TOKEN, CRAFT_CLOUD_SIGNING_KEY } = process.env;
+
 export async function queryCraft(query, variables = {}) {
   const method = 'POST';
-  const url = `${process.env.CRAFT_URL}/api`;
+  const url = `${CRAFT_URL}/api`;
   const body = JSON.stringify({ query, variables });
   const created = new Date();
 
@@ -62,7 +62,7 @@ export async function queryCraft(query, variables = {}) {
         alg: 'hmac-sha256',
         signSync(data) {
           return crypto
-            .createHmac('sha256', process.env.CRAFT_CLOUD_SIGNING_KEY)
+            .createHmac('sha256', CRAFT_CLOUD_SIGNING_KEY)
             .update(data)
             .digest();
         },
@@ -78,7 +78,7 @@ export async function queryCraft(query, variables = {}) {
       body,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${process.env.CRAFT_GRAPHQL_TOKEN}`,
+        'Authorization': `Bearer ${CRAFT_GRAPHQL_TOKEN}`,
         ...signatureHeaders,
       },
       retry: {

--- a/docs/cloud/headless.md
+++ b/docs/cloud/headless.md
@@ -11,8 +11,8 @@ builds and background revalidation.
 
 Two components are critical for a successful headless setup on Craft Cloud:
 
-- **Signed requests:**
-  - [Sign requests](request-signing.md) from trusted server-side code so they
+- **Request signing:**
+  - Use [request signing](request-signing.md) from trusted server-side code to
     bypass the untrusted-bot policy.
   - Signatures do not bypass shared capacity limits, so signed requests can
     still receive `429` or `503` responses.

--- a/docs/cloud/headless.md
+++ b/docs/cloud/headless.md
@@ -27,90 +27,245 @@ Two components are critical for a successful headless setup on Craft Cloud:
   - Throw after retries are exhausted so stale-while-revalidate caching can
     preserve the last successful result.
 
-## Examples
+## Automated Retries
 
-### Next.js on Vercel
-
-This example uses [Ky](https://github.com/sindresorhus/ky) to implement that
-retry policy while preserving
-[Next.js fetch options](https://nextjs.org/docs/app/api-reference/functions/fetch).
-
-Install Ky and the signature library used in the general
-[Node.js example](request-signing.md#from-node-js):
-
-```bash
-npm install ky http-message-sig
-```
-
-Create a GraphQL helper:
+A maintained Fetch client such as [Ky](https://github.com/sindresorhus/ky) can
+provide this retry policy. If you prefer not to add a dependency, use a small
+wrapper around the native Fetch API:
 
 ```js
-import crypto from 'node:crypto';
-import { signatureHeadersSync } from 'http-message-sig';
-import ky from 'ky';
+const RETRYABLE_STATUSES = new Set([429, 503]);
+const TOTAL_TIMEOUT = 30_000;
 
-const { CRAFT_URL, CRAFT_GRAPHQL_TOKEN, CRAFT_CLOUD_SIGNING_KEY } = process.env;
+const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
 
-export async function queryCraft(query, variables = {}) {
-  const method = 'POST';
-  const url = `${CRAFT_URL}/api`;
-  const body = JSON.stringify({ query, variables });
-  const created = new Date();
+function getRetryDelay(response, attempt) {
+  const backoff = 1000 * 2 ** attempt * (0.5 + Math.random() / 2);
+  const retryAfter = response.headers.get('Retry-After');
 
-  const signatureHeaders = signatureHeadersSync(
-    { method, url },
-    {
-      key: 'sig',
-      signer: {
-        keyid: 'hmac',
-        alg: 'hmac-sha256',
-        signSync(data) {
-          return crypto
-            .createHmac('sha256', CRAFT_CLOUD_SIGNING_KEY)
-            .update(data)
-            .digest();
-        },
-      },
-      components: ['@method', '@target-uri'],
-      created,
-      expires: new Date(created.getTime() + 60 * 1000),
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+
+    if (Number.isFinite(seconds)) {
+      return Math.max(backoff, seconds * 1000);
     }
-  );
 
-  const result = await ky
-    .post(url, {
-      body,
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${CRAFT_GRAPHQL_TOKEN}`,
-        ...signatureHeaders,
-      },
-      retry: {
-        limit: 1,
-        methods: ['post'],
-        statusCodes: [429, 503],
-        jitter: true,
-      },
-      totalTimeout: 30_000,
-      next: {
-        revalidate: 300,
-        tags: ['craft:blog'],
-      },
-    })
-    .json();
+    const date = Date.parse(retryAfter);
+
+    if (!Number.isNaN(date)) {
+      return Math.max(backoff, date - Date.now());
+    }
+  }
+
+  return backoff;
+}
+
+export async function fetchWithRetry(input, init = {}) {
+  const deadline = Date.now() + TOTAL_TIMEOUT;
+
+  for (let attempt = 0; ; attempt++) {
+    const remaining = deadline - Date.now();
+
+    if (remaining <= 0) {
+      throw new Error('Craft request timed out');
+    }
+
+    const timeoutSignal = AbortSignal.timeout(remaining);
+    const signal = init.signal
+      ? AbortSignal.any([init.signal, timeoutSignal])
+      : timeoutSignal;
+    const response = await fetch(input, { ...init, signal });
+
+    if (response.ok) {
+      return response;
+    }
+
+    const error = new Error(`Craft request failed: ${response.status}`);
+    const canRetry = RETRYABLE_STATUSES.has(response.status);
+
+    await response.body?.cancel();
+
+    if (!canRetry) {
+      throw error;
+    }
+
+    const delay = getRetryDelay(response, attempt);
+
+    if (Date.now() + delay >= deadline) {
+      throw error;
+    }
+
+    await sleep(delay);
+  }
+}
+```
+
+`fetchWithRetry()` retries only `429` and `503` responses that fit within a
+30-second deadline. Retry `POST` requests only when they contain read-only
+GraphQL queries.
+
+## Request Signatures
+
+Create a `request-signatures.js` module using `getSignatureHeaders()` from the
+general [Node.js signing example](request-signing.md#from-node-js). The
+framework examples below import that helper so signing does not interfere with
+framework-specific request options.
+
+## Next.js Example
+
+[Next.js extends `fetch()`](https://nextjs.org/docs/app/api-reference/functions/fetch)
+with cache and revalidation options. This example uses
+[Ky](https://github.com/sindresorhus/ky), which passes those options through to
+the underlying Fetch implementation. Install it with `npm install ky`:
+
+```js
+import ky from 'ky';
+import { getSignatureHeaders } from './request-signatures.js';
+
+const { CRAFT_URL, CRAFT_GRAPHQL_TOKEN } = process.env;
+const method = 'POST';
+const url = `${CRAFT_URL}/api`;
+const query = `{ entries(section: "blog") { title url } }`;
+const body = JSON.stringify({ query });
+const signatureHeaders = getSignatureHeaders(method, url);
+
+const result = await ky.post(url, {
+  body,
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${CRAFT_GRAPHQL_TOKEN}`,
+    ...signatureHeaders,
+  },
+  retry: {
+    limit: Number.POSITIVE_INFINITY,
+    methods: ['post'],
+    statusCodes: [429, 503],
+    jitter: true,
+  },
+  timeout: false,
+  totalTimeout: 30_000,
+  next: {
+    revalidate: 300,
+    tags: ['craft:blog'],
+  },
+}).json();
+
+if (result.errors?.length) {
+  throw new Error(result.errors.map((error) => error.message).join('\n'));
+}
+
+const data = result.data;
+```
+
+The 30-second total timeout keeps all attempts and delays within the
+signature’s 60-second lifetime.
+
+Use narrow tags such as `craft:blog` or `craft:products`, and avoid bursts of
+site-wide invalidations. When revalidation throws, Next.js continues serving
+the last successful result and tries again on a later request.
+
+Vercel provides this stale-while-revalidate behavior through
+[ISR](https://vercel.com/docs/incremental-static-regeneration). Netlify’s
+[current Next.js adapter](https://docs.netlify.com/build/frameworks/framework-setup-guides/nextjs/overview/)
+also supports the Full Route and Data caches, including tag- and path-based
+revalidation.
+
+## Nuxt Example
+
+Nuxt’s `$fetch` uses [ofetch](https://github.com/unjs/ofetch#-auto-retry), which
+can retry requests but does not provide this `Retry-After` and backoff policy.
+Keep the signed request in a server route and use the shared helper:
+
+```js
+// server/api/blog.get.js
+import { fetchWithRetry } from '../utils/fetch-with-retry.js';
+import { getSignatureHeaders } from '../utils/request-signatures.js';
+
+const { CRAFT_URL, CRAFT_GRAPHQL_TOKEN } = process.env;
+const method = 'POST';
+const url = `${CRAFT_URL}/api`;
+const query = `{ entries(section: "blog") { title url } }`;
+const body = JSON.stringify({ query });
+
+export default defineEventHandler(async () => {
+  const signatureHeaders = getSignatureHeaders(method, url);
+  const response = await fetchWithRetry(url, {
+    method,
+    body,
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${CRAFT_GRAPHQL_TOKEN}`,
+      ...signatureHeaders,
+    },
+  });
+  const result = await response.json();
 
   if (result.errors?.length) {
     throw new Error(result.errors.map((error) => error.message).join('\n'));
   }
 
   return result.data;
-}
+});
 ```
 
-The 30-second overall timeout keeps the retry within the signature’s 60-second
-lifetime. If the request still fails, Ky throws, allowing
-[Vercel ISR](https://vercel.com/docs/incremental-static-regeneration) to treat a
-revalidation as failed and preserve the last successful result.
+Apply stale-while-revalidate caching with a route rule, then call the route
+from your components with `useFetch('/api/blog')`:
 
-Adjust `next.revalidate` for your content. Use narrow tags such as `craft:blog`
-or `craft:products`, and avoid bursts of site-wide invalidations.
+```js
+// nuxt.config.js
+export default defineNuxtConfig({
+  routeRules: {
+    '/api/blog': { swr: 300 },
+  },
+});
+```
+
+Nuxt also supports an `isr` route rule on Vercel and Netlify, but adapter
+behavior differs. Netlify currently documents a
+[cache-control limitation for Nuxt ISR routes](https://docs.netlify.com/build/caching/caching-overview/),
+so verify the deployed response before relying on CDN caching.
+
+## Astro Example
+
+Astro prerenders pages by default, so a failed Craft request should fail the
+build rather than publish partial content:
+
+```js
+---
+import { fetchWithRetry } from '../lib/fetch-with-retry.js';
+import { getSignatureHeaders } from '../lib/request-signatures.js';
+
+const { CRAFT_URL, CRAFT_GRAPHQL_TOKEN } = process.env;
+const method = 'POST';
+const url = `${CRAFT_URL}/api`;
+const query = `{ entries(section: "blog") { title url } }`;
+const body = JSON.stringify({ query });
+const signatureHeaders = getSignatureHeaders(method, url);
+const response = await fetchWithRetry(url, {
+  method,
+  body,
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${CRAFT_GRAPHQL_TOKEN}`,
+    ...signatureHeaders,
+  },
+});
+const result = await response.json();
+
+if (result.errors?.length) {
+  throw new Error(result.errors.map((error) => error.message).join('\n'));
+}
+
+const data = result.data;
+---
+```
+
+Netlify uses [atomic deploys](https://docs.netlify.com/deploy/deploy-overview/),
+and Vercel promotes successful deployments to production. A failed build
+therefore leaves the current production site in place.
+
+For on-demand rendering, Astro 7 provides a
+[route cache API](https://docs.astro.build/en/guides/caching/) with
+stale-while-revalidate semantics. Its Netlify and Vercel CDN cache providers
+are currently experimental, so use the static build approach unless runtime
+revalidation is required.

--- a/docs/cloud/headless.md
+++ b/docs/cloud/headless.md
@@ -1,0 +1,127 @@
+---
+description: Reliably connect a headless site to a Craft Cloud environment.
+---
+
+# Headless
+
+A headless site typically runs its front end separately from Craft Cloud and
+retrieves content from Craft’s [GraphQL API](/5.x/development/graphql.md).
+Static builds and background revalidation can generate concentrated bursts of
+requests, so the front end must be prepared for temporary capacity limits.
+
+Use this contract regardless of your front-end framework or hosting provider:
+
+- [Sign requests](request-signing.md) from trusted server-side code. Never expose
+  the signing key to a browser or in a public environment variable.
+- Treat every non-2xx response as a failure. A verified signature bypasses the
+  untrusted-bot policy, not shared capacity limits, so signed requests may still
+  receive `429` or `503` responses.
+- For `429` and `503` responses, honor `Retry-After` and retry a limited number
+  of times with exponential backoff and jitter.
+- Retry `POST` requests only when they contain read-only GraphQL queries. Never
+  automatically retry mutations.
+- After retries are exhausted, throw an error rather than rendering or caching
+  an incomplete response. Pair this with stale-while-revalidate caching so the
+  front end can continue serving the last successful result.
+
+## Next.js on Vercel
+
+This example uses [Ky](https://github.com/sindresorhus/ky) because it treats
+non-2xx responses as errors and supports `Retry-After`, bounded retries,
+exponential backoff, jitter, and an overall timeout while preserving
+[Next.js fetch options](https://nextjs.org/docs/app/api-reference/functions/fetch).
+
+Install Ky and the same signature library used in the general
+[Node.js signing example](request-signing.md#from-node-js):
+
+```bash
+npm install ky http-message-sig
+```
+
+Configure `CRAFT_URL`, `CRAFT_GRAPHQL_TOKEN`, and
+`CRAFT_CLOUD_SIGNING_KEY` as server-side environment variables, then create a
+GraphQL helper:
+
+```js
+import crypto from 'node:crypto';
+import { signatureHeadersSync } from 'http-message-sig';
+import ky from 'ky';
+
+export async function queryCraft(query, variables = {}) {
+  const method = 'POST';
+  const url = `${process.env.CRAFT_URL}/api`;
+  const body = JSON.stringify({ query, variables });
+  const created = new Date();
+
+  const signatureHeaders = signatureHeadersSync(
+    { method, url },
+    {
+      key: 'sig',
+      signer: {
+        keyid: 'hmac',
+        alg: 'hmac-sha256',
+        signSync(data) {
+          return crypto
+            .createHmac('sha256', process.env.CRAFT_CLOUD_SIGNING_KEY)
+            .update(data)
+            .digest();
+        },
+      },
+      components: ['@method', '@target-uri'],
+      created,
+      expires: new Date(created.getTime() + 60 * 1000),
+    }
+  );
+
+  const result = await ky
+    .post(url, {
+      body,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${process.env.CRAFT_GRAPHQL_TOKEN}`,
+        ...signatureHeaders,
+      },
+      retry: {
+        limit: 1,
+        methods: ['post'],
+        statusCodes: [429, 503],
+        jitter: true,
+      },
+      totalTimeout: 30_000,
+      next: {
+        revalidate: 300,
+        tags: ['craft:blog'],
+      },
+    })
+    .json();
+
+  if (result.errors?.length) {
+    throw new Error(result.errors.map((error) => error.message).join('\n'));
+  }
+
+  return result.data;
+}
+```
+
+The single retry keeps the request within the signature’s 60-second lifetime,
+and Ky throws after the retry or 30-second overall timeout. This allows
+[Vercel ISR](https://vercel.com/docs/incremental-static-regeneration) to treat a
+background revalidation as failed and preserve the last successful result.
+
+The `next` values are examples. Choose a revalidation interval appropriate for
+your content, and use narrow tags such as `craft:blog`, `craft:products`, or a
+specific section or entry. Prefer targeted revalidation over invalidating the
+entire site, and avoid triggering large bursts of invalidations when content is
+updated in bulk.
+
+## Diagnostics
+
+When a request fails, inspect its status and these response headers in your
+front-end deployment logs:
+
+- `x-gateway-http-signature` contains request-signature diagnostics;
+- `x-gateway-rate-limit` identifies applicable gateway rate limiting; and
+- `Retry-After` tells the caller how long to wait before retrying a `429` or
+  `503` response.
+
+Do not log signing keys or GraphQL tokens while collecting diagnostics.

--- a/docs/cloud/headless.md
+++ b/docs/cloud/headless.md
@@ -119,8 +119,7 @@ updated in bulk.
 When a request fails, inspect its status and these response headers in your
 front-end deployment logs:
 
-- `x-gateway-http-signature` contains request-signature diagnostics;
-- `x-gateway-rate-limit` identifies applicable gateway rate limiting; and
+- `x-gateway-http-signature` contains request-signature diagnostics; and
 - `Retry-After` tells the caller how long to wait before retrying a `429` or
   `503` response.
 

--- a/docs/cloud/headless.md
+++ b/docs/cloud/headless.md
@@ -27,7 +27,9 @@ Two components are critical for a successful headless setup on Craft Cloud:
   - Throw after retries are exhausted so stale-while-revalidate caching can
     preserve the last successful result.
 
-## Next.js on Vercel
+## Examples
+
+### Next.js on Vercel
 
 This example uses [Ky](https://github.com/sindresorhus/ky) to implement that
 retry policy while preserving

--- a/docs/cloud/headless.md
+++ b/docs/cloud/headless.md
@@ -11,16 +11,21 @@ builds and background revalidation.
 
 Two components are critical for a successful headless setup on Craft Cloud:
 
-- **Signed requests:** [Sign requests](request-signing.md) from trusted
-  server-side code so they bypass the untrusted-bot policy. Signatures do not
-  bypass shared capacity limits, so signed requests can still receive `429` or
-  `503` responses. Never expose the signing key to a browser or in a public
-  environment variable.
-- **Automated retries:** Treat every non-2xx response as a failure. For `429` and
-  `503` responses, honor `Retry-After` and use bounded retries with exponential
-  backoff and jitter. Only retry `POST` requests that contain read-only GraphQL
-  queries—never mutations. Throw after retries are exhausted so
-  stale-while-revalidate caching can preserve the last successful result.
+- **Signed requests:**
+  - [Sign requests](request-signing.md) from trusted server-side code so they
+    bypass the untrusted-bot policy.
+  - Signatures do not bypass shared capacity limits, so signed requests can
+    still receive `429` or `503` responses.
+  - Never expose the signing key to a browser or in a public environment
+    variable.
+- **Automated retries:**
+  - Treat every non-2xx response as a failure.
+  - For `429` and `503` responses, honor `Retry-After` and use bounded retries
+    with exponential backoff and jitter.
+  - Only retry `POST` requests that contain read-only GraphQL queries—never
+    mutations.
+  - Throw after retries are exhausted so stale-while-revalidate caching can
+    preserve the last successful result.
 
 ## Next.js on Vercel
 

--- a/docs/cloud/request-signing.md
+++ b/docs/cloud/request-signing.md
@@ -6,7 +6,7 @@ description: Sign trusted programmatic requests to avoid bot rate limiting.
 
 Request signing allows trusted systems to make programmatic requests to Craft Cloud without being treated like unsanctioned bot traffic.
 
-This is useful for automated systems like static site builds or CI/CD pipelines, which will often be identified (correctly!) as “bots” and be rate-limited more aggressively than browsers.
+This is useful for automated systems like static app builds or CI/CD pipelines, which will often be identified (correctly!) as “bots” and be rate-limited more aggressively than browsers.
 
 Each environment’s `$CRAFT_CLOUD_SIGNING_KEY` [system variable](environments.md#variables) is used as a shared secret when generating and validating signed requests.
 
@@ -15,7 +15,7 @@ For more details on RFC 9421 HTTP Message Signatures, see [httpsig.org](https://
 :::
 
 ::: tip
-If you are building a headless site, also follow the [Headless guide](headless.md)
+If you are building a headless app, also follow the [Headless Apps guide](headless-apps.md)
 for required retry and caching behavior.
 :::
 

--- a/docs/cloud/request-signing.md
+++ b/docs/cloud/request-signing.md
@@ -14,6 +14,11 @@ Each environment’s `$CRAFT_CLOUD_SIGNING_KEY` [system variable](environments.m
 For more details on RFC 9421 HTTP Message Signatures, see [httpsig.org](https://httpsig.org/).
 :::
 
+::: tip
+If you are building a headless site, also follow the [Headless guide](headless.md)
+for required retry and caching behavior.
+:::
+
 ## Creating a Signed Request
 
 External systems can generate valid signatures for a Craft Cloud environment, provided the corresponding `$CRAFT_CLOUD_SIGNING_KEY`.
@@ -23,17 +28,51 @@ A signed request is not consumed (like a token URL is, in Craft), and they are n
 
 ### From Node.js
 
-This example uses [`http-message-sig`](https://www.npmjs.com/package/http-message-sig) to generate an RFC 9421-compliant signature:
+This example uses [`http-message-sig`](https://www.npmjs.com/package/http-message-sig) for convenience, but the package is not required. You may use any RFC 9421-compatible implementation.
 
 ```bash
 npm install http-message-sig
 ```
 
-Build and send a signed request like this:
+Create a reusable `request-signatures.js` helper:
 
 ```js
 import crypto from 'node:crypto';
 import { signatureHeadersSync } from 'http-message-sig';
+
+const { CRAFT_CLOUD_SIGNING_KEY } = process.env;
+
+export function getSignatureHeaders(method, url) {
+  const created = new Date();
+
+  return signatureHeadersSync(
+    { method, url },
+    {
+      key: 'sig',
+      signer: {
+        keyid: 'hmac',
+        alg: 'hmac-sha256',
+        signSync(data) {
+          return crypto
+            .createHmac('sha256', CRAFT_CLOUD_SIGNING_KEY)
+            .update(data)
+            .digest();
+        },
+      },
+      components: ['@method', '@target-uri'],
+      created,
+
+      // Optional 60-second expiry. The maximum is five minutes.
+      expires: new Date(created.getTime() + 60 * 1000),
+    }
+  );
+}
+```
+
+Import the helper when sending a signed request:
+
+```js
+import { getSignatureHeaders } from './request-signatures.js';
 
 const method = 'POST';
 const url = 'https://my-env.some-domain.com/api';
@@ -42,31 +81,7 @@ const body = JSON.stringify({
   query: `{ entries(section: "blog") { title url } }`,
 });
 
-const created = new Date();
-
-const signer = {
-  keyid: 'hmac',
-  alg: 'hmac-sha256',
-  signSync(data) {
-    return crypto
-      .createHmac('sha256', process.env.CRAFT_CLOUD_SIGNING_KEY)
-      .update(data)
-      .digest();
-  },
-};
-
-const signatureHeaders = signatureHeadersSync(
-  { method, url },
-  {
-    key: 'sig',
-    signer,
-    components: ['@method', '@target-uri'],
-    created,
-
-    // Optional 60-second expiry. The maximum is five minutes.
-    expires: new Date(created.getTime() + 60 * 1000),
-  }
-);
+const signatureHeaders = getSignatureHeaders(method, url);
 
 const response = await fetch(url, {
   method,

--- a/docs/cloud/request-signing.md
+++ b/docs/cloud/request-signing.md
@@ -68,7 +68,7 @@ const signatureHeaders = signatureHeadersSync(
   }
 );
 
-await fetch(url, {
+const response = await fetch(url, {
   method,
   headers: {
     'Content-Type': 'application/json',
@@ -77,6 +77,10 @@ await fetch(url, {
   },
   body,
 });
+
+if (!response.ok) {
+  throw new Error(`Craft request failed: ${response.status}`);
+}
 ```
 
 ::: tip

--- a/docs/cloud/request-signing.md
+++ b/docs/cloud/request-signing.md
@@ -30,10 +30,6 @@ A signed request is not consumed (like a token URL is, in Craft), and they are n
 
 This example uses [`http-message-sig`](https://www.npmjs.com/package/http-message-sig) for convenience, but the package is not required. You may use any RFC 9421-compatible implementation.
 
-```bash
-npm install http-message-sig
-```
-
 Create a reusable `request-signatures.js` helper:
 
 ```js
@@ -42,11 +38,14 @@ import { signatureHeadersSync } from 'http-message-sig';
 
 const { CRAFT_CLOUD_SIGNING_KEY } = process.env;
 
-export function getSignatureHeaders(method, url) {
+export function getSignatureHeaders(
+  request,
+  components = ['@method', '@target-uri']
+) {
   const created = new Date();
 
   return signatureHeadersSync(
-    { method, url },
+    request,
     {
       key: 'sig',
       signer: {
@@ -59,7 +58,7 @@ export function getSignatureHeaders(method, url) {
             .digest();
         },
       },
-      components: ['@method', '@target-uri'],
+      components,
       created,
 
       // Optional 60-second expiry. The maximum is five minutes.
@@ -69,25 +68,32 @@ export function getSignatureHeaders(method, url) {
 }
 ```
 
+Pass additional [covered components](https://www.rfc-editor.org/rfc/rfc9421.html#name-http-message-components), such as `content-type`, in the second argument when those values must also be signed.
+
 Import the helper when sending a signed request:
 
 ```js
 import { getSignatureHeaders } from './request-signatures.js';
 
-const method = 'POST';
-const url = 'https://my-env.some-domain.com/api';
+const request = {
+  method: 'POST',
+  url: 'https://my-env.some-domain.com/api',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer my-secret-gql-schema-token',
+  },
+};
 
 const body = JSON.stringify({
   query: `{ entries(section: "blog") { title url } }`,
 });
 
-const signatureHeaders = getSignatureHeaders(method, url);
+const signatureHeaders = getSignatureHeaders(request);
 
-const response = await fetch(url, {
-  method,
+const response = await fetch(request.url, {
+  method: request.method,
   headers: {
-    'Content-Type': 'application/json',
-    'Authorization': 'Bearer my-secret-gql-schema-token',
+    ...request.headers,
     ...signatureHeaders,
   },
   body,
@@ -100,7 +106,7 @@ if (!response.ok) {
 
 ::: tip
 Requests signed using the `@target-uri` [component](https://www.rfc-editor.org/rfc/rfc9421.html#name-derived-components) are only valid when sent to a URL that matches _exactly_, including the scheme, hostname, path, and query string.
-The example above satisfies this by using the same `url` variable for the signed request and the `fetch()` call.
+The example above satisfies this by using the same `request.url` value for signing and the `fetch()` call.
 :::
 
 ### From Grafana Cloud k6

--- a/docs/cloud/request-signing.md
+++ b/docs/cloud/request-signing.md
@@ -38,6 +38,10 @@ import { signatureHeadersSync } from 'http-message-sig';
 
 const { CRAFT_CLOUD_SIGNING_KEY } = process.env;
 
+if (!CRAFT_CLOUD_SIGNING_KEY) {
+  throw new Error('CRAFT_CLOUD_SIGNING_KEY is not set');
+}
+
 export function getSignatureHeaders(
   request,
   components = ['@method', '@target-uri']

--- a/docs/cloud/request-signing.md
+++ b/docs/cloud/request-signing.md
@@ -65,8 +65,8 @@ export function getSignatureHeaders(
       components,
       created,
 
-      // Optional 60-second expiry. The maximum is five minutes.
-      expires: new Date(created.getTime() + 60 * 1000),
+      // Optional expiry. The maximum is five minutes.
+      // expires: new Date(created.getTime() + 60 * 1000),
     }
   );
 }


### PR DESCRIPTION
Adds a Headless Apps guide for resilient signed GraphQL requests, bounded retries, and framework caching patterns. Updates the Node.js signing example with a reusable helper and clear request failures.