### PR TITLE
Open Graph Preview Images

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -32,6 +32,7 @@ module.exports = {
       }
     ],
     [require("./plugins/craft.js")],
+    [require("./plugins/og.js")],
   ],
   shouldPrefetch: () => false,
   head: require("./head"),

--- a/docs/.vuepress/plugins/og.js
+++ b/docs/.vuepress/plugins/og.js
@@ -1,0 +1,26 @@
+module.exports = function(options, ctx) {
+  return {
+    name: 'og',
+    extendPageData(page) {
+
+      const path = (page.regularPath || '/')
+        .replace(/\/+$/, '')
+        .replace(/\.html$/, '');
+
+      // https://craftcms.com/api/og-image/docs/5.x/editions
+      const newFrontmatter = [
+        {
+          property: 'og:image',
+          content: `https://craftcms.com/api/og-image/docs${path}`
+        },
+      ];
+
+      const frontmatter = [
+        ...(page.frontmatter.meta || []),
+        ...newFrontmatter,
+      ];
+
+      page.frontmatter.meta = frontmatter;
+    }
+  }
+}


### PR DESCRIPTION
Kenneth has set up Cloud’s “open-beta” screenshot capturing tool to dynamically generate preview images for all docs + KB pages; this just adds the appropriate `head` tags that point to stable `craftcms.com` redirects… so, we don't need to know the full URL of the asset (which may change over time), just the path.

For example, a request to…

```
https://craftcms.com/api/og-image/docs/5.x/editions
```

…will respond with a redirect, like this:

```
HTTP/2 302
Location: https://cdn.craft.cloud/[[ Project UUID ]]/assets/card-image/[[ Filename with entropy ]].png
```

Images are generated in the background when an entry is saved.